### PR TITLE
Issue 9 - Make the AST position aware, use that for TypeNotFoundException, and pretty print exceptions in general

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ included file `LICENSE`.
 - Robey Pointer
 - Ian Ownbey
 - Jeremy Cloud
+- Aaron Stone

--- a/src/main/scala/com/twitter/handlebar/Handlebar.scala
+++ b/src/main/scala/com/twitter/handlebar/Handlebar.scala
@@ -17,6 +17,7 @@
 package com.twitter.handlebar
 
 import scala.util.parsing.input.StreamReader
+import java.io.StringReader
 
 case class Unpacker[T](
   document: AST.Document,
@@ -29,6 +30,9 @@ case class Unpacker[T](
 object Handlebar {
   import AST._
   import Dictionary._
+
+  def generate(template: String, dictionary: Dictionary): String =
+    generate(Parser(StreamReader(new StringReader(template))), dictionary)
 
   def generate(template: StreamReader, dictionary: Dictionary): String =
     generate(Parser(template), dictionary)
@@ -64,6 +68,7 @@ object Handlebar {
 
 case class Handlebar(document: AST.Document) {
   def this(template: StreamReader) = this(Parser(template))
+  def this(template: String) = this(StreamReader(new StringReader(template)))
 
   /**
    * Create a string out of a template, using a dictionary to fill in the blanks.

--- a/src/main/scala/com/twitter/handlebar/Handlebar.scala
+++ b/src/main/scala/com/twitter/handlebar/Handlebar.scala
@@ -16,6 +16,8 @@
 
 package com.twitter.handlebar
 
+import scala.util.parsing.input.StreamReader
+
 case class Unpacker[T](
   document: AST.Document,
   unpacker: T => Dictionary,
@@ -28,7 +30,7 @@ object Handlebar {
   import AST._
   import Dictionary._
 
-  def generate(template: String, dictionary: Dictionary): String =
+  def generate(template: StreamReader, dictionary: Dictionary): String =
     generate(Parser(template), dictionary)
 
   def generate(document: Document, dictionary: Dictionary): String = {
@@ -61,7 +63,7 @@ object Handlebar {
 }
 
 case class Handlebar(document: AST.Document) {
-  def this(template: String) = this(Parser(template))
+  def this(template: StreamReader) = this(Parser(template))
 
   /**
    * Create a string out of a template, using a dictionary to fill in the blanks.

--- a/src/main/scala/com/twitter/handlebar/Parser.scala
+++ b/src/main/scala/com/twitter/handlebar/Parser.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable
 import scala.util.parsing.combinator._
 import scala.util.parsing.combinator.lexical._
 import scala.util.parsing.input.StreamReader
+import java.io.StringReader
 
 class ParseException(reason: String, cause: Throwable) extends Exception(reason, cause) {
   def this(reason: String) = this(reason, null)
@@ -74,6 +75,7 @@ object Parser extends RegexParsers {
       }
     }
   }
+  def apply(in: String): Document = apply(StreamReader(new StringReader(in)))
 }
 
 /**

--- a/src/main/scala/com/twitter/handlebar/Parser.scala
+++ b/src/main/scala/com/twitter/handlebar/Parser.scala
@@ -19,6 +19,7 @@ package com.twitter.handlebar
 import scala.collection.mutable
 import scala.util.parsing.combinator._
 import scala.util.parsing.combinator.lexical._
+import scala.util.parsing.input.StreamReader
 
 class ParseException(reason: String, cause: Throwable) extends Exception(reason, cause) {
   def this(reason: String) = this(reason, null)
@@ -64,7 +65,7 @@ object Parser extends RegexParsers {
   def id = """[A-Za-z0-9_\.]+""".r
 
   // rawr.
-  def apply(in: String): Document = {
+  def apply(in: StreamReader): Document = {
     CleanupWhitespace {
       parseAll(document, in) match {
         case Success(result, _) => result

--- a/src/main/scala/com/twitter/scrooge/AST.scala
+++ b/src/main/scala/com/twitter/scrooge/AST.scala
@@ -16,8 +16,10 @@
 
 package com.twitter.scrooge
 
+import scala.util.parsing.input.Positional
+
 object AST {
-  sealed abstract class Node
+  sealed abstract class Node extends Positional
   sealed abstract class Requiredness extends Node {
     def isOptional = this eq Requiredness.Optional
     def isRequired = this eq Requiredness.Required

--- a/src/main/scala/com/twitter/scrooge/Main.scala
+++ b/src/main/scala/com/twitter/scrooge/Main.scala
@@ -95,6 +95,8 @@ object Main {
       val parser = new ScroogeParser(importer)
       val doc0 = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
 
+      println(doc0) // FIXME: remove this after debugging AST positional error output
+
       val outputFile = outputFilename map { new File(_) } getOrElse generator.outputFile(destFolder, doc0, inputFile)
       val lastModified = importer.lastModified(inputFile).getOrElse(Long.MaxValue)
       if (!(skipUnchanged && isUnchanged(outputFile, lastModified))) {

--- a/src/main/scala/com/twitter/scrooge/Main.scala
+++ b/src/main/scala/com/twitter/scrooge/Main.scala
@@ -99,10 +99,11 @@ object Main {
         val doc0 = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
         val outputFile = outputFilename map { new File(_) } getOrElse generator.outputFile(destFolder, doc0, inputFile)
         val lastModified = importer.lastModified(inputFile).getOrElse(Long.MaxValue)
+
         if (skipUnchanged && isUnchanged(outputFile, lastModified)) {
           if (verbose) print(" (unchanged)")
-        } else {
 
+        } else {
           val doc1 = TypeResolver().resolve(doc0).document
           val content = generator(doc1, flags.toSet)
 

--- a/src/main/scala/com/twitter/scrooge/MustacheLoader.scala
+++ b/src/main/scala/com/twitter/scrooge/MustacheLoader.scala
@@ -20,6 +20,8 @@ import com.twitter.conversions.string._
 import com.twitter.handlebar.Handlebar
 import scala.collection.mutable.HashMap
 import scala.io.Source
+import scala.util.parsing.input.StreamReader
+import java.io.{FileInputStream, InputStreamReader}
 
 class HandlebarLoader(prefix: String, suffix: String = ".scala") {
   private val cache = new HashMap[String, Handlebar]
@@ -32,7 +34,7 @@ class HandlebarLoader(prefix: String, suffix: String = ".scala") {
           throw new NoSuchElementException("template not found: " + fullName)
         }
         case inputStream => {
-          new Handlebar(Source.fromInputStream(inputStream).getLines().mkString("\n"))
+          new Handlebar(StreamReader(new InputStreamReader(inputStream)))
         }
       }
     )

--- a/src/main/scala/com/twitter/scrooge/ScroogeParser.scala
+++ b/src/main/scala/com/twitter/scrooge/ScroogeParser.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
 import scala.util.parsing.combinator._
 import scala.util.parsing.combinator.lexical._
 import scala.util.parsing.input.{Positional, StreamReader}
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{FileInputStream, InputStreamReader, StringReader}
 
 class ParseException(reason: String, cause: Throwable) extends Exception(reason, cause) {
   def this(reason: String) = this(reason, null)
@@ -224,7 +224,6 @@ class ScroogeParser(importer: Importer) extends RegexParsers {
   def namespaceScope = "*" | (identifier ^^ { id => id.name })
 
   // rawr.
-
   def parse[T](in: StreamReader, parser: Parser[T]): T = {
     parseAll(parser, in) match {
       case Success(result, _) => result
@@ -232,6 +231,7 @@ class ScroogeParser(importer: Importer) extends RegexParsers {
       case x @ Error(msg, _) => throw new ParseException(x.toString)
     }
   }
+  def parse[T](in: String, parser: Parser[T]): T = parse(StreamReader(new StringReader(in)), parser)
 
   def parseFile(filename: String) = parse(StreamReader(new InputStreamReader(new FileInputStream((filename)))), document)
 }

--- a/src/main/scala/com/twitter/scrooge/ScroogeParser.scala
+++ b/src/main/scala/com/twitter/scrooge/ScroogeParser.scala
@@ -79,7 +79,7 @@ class ScroogeParser(importer: Importer) extends RegexParsers {
     MapConstant(Map(list.map { case k ~ x ~ v => (k, v) }: _*))
   }
 
-  def identifier = "[A-Za-z_][A-Za-z0-9\\._]*".r ^^ { x => Identifier(x) }
+  def identifier = positioned("[A-Za-z_][A-Za-z0-9\\._]*".r ^^ { x => Identifier(x) })
 
   // types
 
@@ -87,17 +87,17 @@ class ScroogeParser(importer: Importer) extends RegexParsers {
 
   def referenceType = identifier ^^ { x => ReferenceType(x.name) }
 
-  def definitionType = baseType | containerType
+  def definitionType = positioned(baseType) | positioned(containerType)
 
   def baseType: Parser[BaseType] = (
-    positioned("bool" ^^^ TBool) |
-    positioned("byte" ^^^ TByte) |
-    positioned("i16" ^^^ TI16) |
-    positioned("i32" ^^^ TI32) |
-    positioned("i64" ^^^ TI64) |
-    positioned("double" ^^^ TDouble) |
-    positioned("string" ^^^ TString) |
-    positioned("binary" ^^^ TBinary)
+    "bool" ^^^ TBool |
+    "byte" ^^^ TByte |
+    "i16" ^^^ TI16 |
+    "i32" ^^^ TI32 |
+    "i64" ^^^ TI64 |
+    "double" ^^^ TDouble |
+    "string" ^^^ TString |
+    "binary" ^^^ TBinary
   )
 
   def containerType: Parser[ContainerType] = mapType | setType | listType
@@ -157,7 +157,7 @@ class ScroogeParser(importer: Importer) extends RegexParsers {
 
   // definitions
 
-  def definition = const | typedef | enum | senum | struct | exception | service
+  def definition = positioned(const) | positioned(typedef) | positioned(enum) | positioned(senum) | positioned(struct) | positioned(exception) | positioned(service)
 
   def const = "const" ~> fieldType ~ identifier ~ ("=" ~> constant) ~ opt(listSeparator) ^^ {
     case ftype ~ id ~ const ~ _ => Const(id.name, ftype, const)

--- a/src/main/scala/com/twitter/scrooge/ScroogeParser.scala
+++ b/src/main/scala/com/twitter/scrooge/ScroogeParser.scala
@@ -228,7 +228,7 @@ class ScroogeParser(importer: Importer) extends RegexParsers {
   def parse[T](in: StreamReader, parser: Parser[T]): T = {
     parseAll(parser, in) match {
       case Success(result, _) => result
-      case x @ Failure(msg, z) => throw new ParseException(x.toString)
+      case x @ Failure(msg, _) => throw new ParseException(x.toString)
       case x @ Error(msg, _) => throw new ParseException(x.toString)
     }
   }

--- a/src/main/scala/com/twitter/scrooge/TypeResolver.scala
+++ b/src/main/scala/com/twitter/scrooge/TypeResolver.scala
@@ -158,7 +158,7 @@ case class TypeResolver(
     copy(serviceMap = serviceMap + (service.name -> service))
   }
 
-  def apply(definition: Definition): Definition = {
+  def apply(definition: Definition): Definition = dynCurrentNode.withValue(definition) {
     definition match {
       case d @ Typedef(name, t) => d.copy(`type` = apply(t))
       case s @ Struct(_, fs) => s.copy(fields = fs.map(apply))
@@ -183,57 +183,63 @@ case class TypeResolver(
       default = f.default.map { const => apply(const, fieldType) })
   }
 
-  def apply(t: FunctionType): FunctionType = t match {
-    case Void => Void
-    case t: FieldType => apply(t)
+  def apply(t: FunctionType): FunctionType = dynCurrentNode.withValue(t) {
+    t match {
+      case Void => Void
+      case t: FieldType => apply(t)
+    }
   }
 
-  def apply(t: FieldType): FieldType = t match {
-    case ReferenceType(name) => apply(name)
-    case m @ MapType(k, v, _) => m.copy(keyType = apply(k), valueType = apply(v))
-    case s @ SetType(e, _) => s.copy(eltType = apply(e))
-    case l @ ListType(e, _) => l.copy(eltType = apply(e))
-    case _ => t
+  def apply(t: FieldType): FieldType = dynCurrentNode.withValue(t) {
+    t match {
+      case ReferenceType(name) => apply(name)
+      case m @ MapType(k, v, _) => m.copy(keyType = apply(k), valueType = apply(v))
+      case s @ SetType(e, _) => s.copy(eltType = apply(e))
+      case l @ ListType(e, _) => l.copy(eltType = apply(e))
+      case _ => t
+    }
   }
 
-  def apply(c: Constant, fieldType: FieldType): Constant = c match {
-    case l @ ListConstant(elems) =>
-      fieldType match {
-        case ListType(eltType, _) => l.copy(elems = elems map { e => apply(e, eltType) } )
-        case SetType(eltType, _) => SetConstant(elems map { e => apply(e, eltType) } toSet)
-        case _ => throw new TypeMismatchException("Expecting " + fieldType + ", found " + l)
-      }
-    case m @ MapConstant(elems) =>
-      fieldType match {
-        case MapType(keyType, valType, _) =>
-          m.copy(elems = elems.map { case (k, v) => (apply(k, keyType), apply(v, valType)) })
-        case _ => throw new TypeMismatchException("Expecting " + fieldType + ", found " + m)
-      }
-    case i @ Identifier(name) =>
-      fieldType match {
-        case EnumType(enum, _) =>
-          val valueName = name match {
-            case QualifiedName(scope, QualifiedName(enumName, valueName)) =>
-              if (fieldTypeResolver(scope, enumName) != fieldType) {
-                throw new UndefinedSymbolException(scope + "." + enumName)
-              } else {
-                valueName
-              }
-            case QualifiedName(enumName, valueName) =>
-              if (enumName != enum.name) {
-                throw new UndefinedSymbolException(enumName)
-              } else {
-                valueName
-              }
-            case _ => name
-          }
-          enum.values.find(_.name == valueName) match {
-            case None => throw new UndefinedSymbolException(name)
-            case Some(value) => EnumValueConstant(enum, value)
-          }
-        case _ => throw new UndefinedSymbolException(name)
-      }
-    case _ => c
+  def apply(c: Constant, fieldType: FieldType): Constant = dynCurrentNode.withValue(c) {
+    c match {
+      case l @ ListConstant(elems) =>
+        fieldType match {
+          case ListType(eltType, _) => l.copy(elems = elems map { e => apply(e, eltType) } )
+          case SetType(eltType, _) => SetConstant(elems map { e => apply(e, eltType) } toSet)
+          case _ => throw new TypeMismatchException("Expecting " + fieldType + ", found " + l)
+        }
+      case m @ MapConstant(elems) =>
+        fieldType match {
+          case MapType(keyType, valType, _) =>
+            m.copy(elems = elems.map { case (k, v) => (apply(k, keyType), apply(v, valType)) })
+          case _ => throw new TypeMismatchException("Expecting " + fieldType + ", found " + m)
+        }
+      case i @ Identifier(name) =>
+        fieldType match {
+          case EnumType(enum, _) =>
+            val valueName = name match {
+              case QualifiedName(scope, QualifiedName(enumName, valueName)) =>
+                if (fieldTypeResolver(scope, enumName) != fieldType) {
+                  throw new UndefinedSymbolException(scope + "." + enumName)
+                } else {
+                  valueName
+                }
+              case QualifiedName(enumName, valueName) =>
+                if (enumName != enum.name) {
+                  throw new UndefinedSymbolException(enumName)
+                } else {
+                  valueName
+                }
+              case _ => name
+            }
+            enum.values.find(_.name == valueName) match {
+              case None => throw new UndefinedSymbolException(name)
+              case Some(value) => EnumValueConstant(enum, value)
+            }
+          case _ => throw new UndefinedSymbolException(name)
+        }
+      case _ => c
+    }
   }
 
   def apply(parent: ServiceParent): ServiceParent = {

--- a/src/test/scala/com/twitter/scrooge/ScroogeParserSpec.scala
+++ b/src/test/scala/com/twitter/scrooge/ScroogeParserSpec.scala
@@ -162,7 +162,7 @@ class ScroogeParserSpec extends Specification {
 
     "standard test file" in {
       val parser = new ScroogeParser(Importer.resourceImporter(getClass))
-      val doc = parser.parseFile("/test.thrift")
+      val doc = parser.parseFile("test.thrift")
       // i guess not blowing up is a good first-pass test.
       // might be nice to verify parts of it tho.
       doc.headers.size mustEqual 13


### PR DESCRIPTION
In these changesets, I implement TypeNotFoundException reporting with the bad type's position in the file.

This is accomplished by:

*  Switching the thrift file input from a slurp-to-String to a StreamReader. This reader annotates the input with position information
*  Adding a Positional mixing to the top level Node class of the AST.
*  Calling the Parser positioned() combinator in useful places in the parser.
*  Subclassing several exceptions from a new ExceptionAt which has a Position instance var.

Caveats:

*  Unit tests not yet updated for the change from String to StreamReader.
*  Exceptions are mostly suppressed, so weird ones might be more confusing now.
*  I've been testing these based off the sbt11 branch because I cannot build locally with sbt 0.7, so these changesets have been cherry-picked to a new branch off master (though no errors or editing needed).