### PR TITLE
Make generator jar executable

### DIFF
--- a/scrooge-generator/pom.xml
+++ b/scrooge-generator/pom.xml
@@ -202,6 +202,20 @@
           </includes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.twitter.scrooge.Main</mainClass>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>libs/</classpathPrefix>
+            </manifest>
+          </archive>
+         </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This change makes the generator jar executable so that it can be used (for example) by the sbt-scrooge project.
