### PR TITLE
Move junit dependency to test scope

### DIFF
--- a/scrooge-generator/pom.xml
+++ b/scrooge-generator/pom.xml
@@ -54,6 +54,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.10</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scala-tools.testing</groupId>


### PR DESCRIPTION
Junit is not needed at runtime. This specifies test scope for junit.
