### PR TITLE
Warning for 'false' equals true

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
@@ -185,6 +185,10 @@ class ThriftParser(importer: Importer, strict: Boolean) extends RegexParsers {
       val transformedVal = ftype match {
         case TBool => value map {
           case IntLiteral(0) => BoolLiteral(false)
+          case IdRHS(SimpleID("false")) => {
+            System.err.println("WARNING: according to Apache Thrift 'false' will translate to a true value, use '0' if you really meant false")
+            BoolLiteral(true)
+          }
           case _ => BoolLiteral(true)
         }
         case _ => value

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
@@ -26,6 +26,8 @@ class ThriftParserSpec extends SpecificationWithJUnit {
       parser.parse("{ 'name': 'Commie', 'home': 'San Francisco' }",
         parser.rhs) mustEqual MapRHS(Map(StringLiteral("name") -> StringLiteral
         ("Commie"), StringLiteral("home") -> StringLiteral("San Francisco")))
+      parser.parse("true", parser.rhs) mustEqual IdRHS(SimpleID("true")) // and not BoolLiteral(true), see #13
+      parser.parse("false", parser.rhs) mustEqual IdRHS(SimpleID("false")) // and not BoolLiteral(false), see #13
     }
 
     "base types" in {


### PR DESCRIPTION
Warn that 'false' is interpreted as true when it is used as a boolean literal. See also #13.