### PR TITLE
Allow unions to contain fields with names of "primitive" types

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")

--- a/scrooge-generator/src/main/resources/scalagen/qualifiedFieldType.scala
+++ b/scrooge-generator/src/main/resources/scalagen/qualifiedFieldType.scala
@@ -1,1 +1,1 @@
-{{^isNamedType}}{{fieldType}}{{/isNamedType}}{{#isNamedType}}{{#isImported}}{{fieldType}}{{/isImported}}{{^isImported}}{{#package}}{{package}}.{{/package}}{{fieldType}}{{/isImported}}{{/isNamedType}}
+{{^isNamedType}}{{fieldTypeWithPackage}}{{/isNamedType}}{{#isNamedType}}{{#isImported}}{{fieldType}}{{/isImported}}{{^isImported}}{{#package}}{{package}}.{{/package}}{{fieldType}}{{/isImported}}{{/isNamedType}}

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ConstsTemplate.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ConstsTemplate.scala
@@ -16,6 +16,7 @@ trait ConstsTemplate {
         Dictionary(
           "name" -> genID(c.sid),
           "fieldType" -> genType(c.fieldType),
+          "fieldTypeWithPackage" -> genType(c.fieldType, false, true),
           "value" -> genConstant(c.value),
           "docstring" -> codify(c.docstring.getOrElse(""))
         )

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
@@ -298,7 +298,7 @@ trait Generator
    */
   def genToImmutable(f: Field): CodeFragment
 
-  def genType(t: FunctionType, mutable: Boolean = false): CodeFragment
+  def genType(t: FunctionType, mutable: Boolean = false, fullyQualify: Boolean = false): CodeFragment
 
   def genPrimitiveType(t: FunctionType, mutable: Boolean = false): CodeFragment
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
@@ -187,21 +187,26 @@ class JavaGenerator(
     codify(code)
   }
 
-  def genType(t: FunctionType, mutable: Boolean = false): CodeFragment = {
+  def genType(t: FunctionType, mutable: Boolean = false, fullyQualify: Boolean = false): CodeFragment = {
+
+    val qualify = (pkg : String, cls : String) => {
+      (if (fullyQualify) pkg + "." else "") + cls
+    }
+
     val code = t match {
       case Void => "Void"
       case OnewayVoid => "Void"
-      case TBool => "Boolean"
-      case TByte => "Byte"
-      case TI16 => "Short"
-      case TI32 => "Integer"
-      case TI64 => "Long"
-      case TDouble => "Double"
-      case TString => "String"
-      case TBinary => "ByteBuffer"
-      case MapType(k, v, _) => "Map<" + genType(k).toData + ", " + genType(v).toData + ">"
-      case SetType(x, _) => "Set<" + genType(x).toData + ">"
-      case ListType(x, _) => "List<" + genType(x).toData + ">"
+      case TBool => qualify("java.lang", "Boolean")
+      case TByte => qualify("java.lang", "Byte")
+      case TI16 => qualify("java.lang", "Short")
+      case TI32 => qualify("java.lang", "Integer")
+      case TI64 => qualify("java.lang", "Long")
+      case TDouble => qualify("java.lang", "Double")
+      case TString => qualify("java.lang", "String")
+      case TBinary => qualify("java.nio", "ByteBuffer")
+      case MapType(k, v, _) => qualify("java.util", "Map<" + genType(k).toData + ", " + genType(v).toData + ">")
+      case SetType(x, _) => qualify("java.util", "Set<" + genType(x).toData + ">")
+      case ListType(x, _) => qualify("java.util", "List<" + genType(x).toData + ">")
       case n: NamedType => genID(qualifyNamedType(n).toTitleCase).toData
       case r: ReferenceType =>
         throw new ScroogeInternalException("ReferenceType should not appear in backend")

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/StructTemplate.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/StructTemplate.scala
@@ -21,6 +21,7 @@ import com.twitter.scrooge.mustache.Dictionary
 import com.twitter.scrooge.mustache.Dictionary._
 import com.twitter.scrooge.frontend.ScroogeInternalException
 
+
 trait StructTemplate {
   self: Generator =>
 
@@ -85,13 +86,15 @@ trait StructTemplate {
         TypeTemplate + Dictionary(
           "isStruct" -> v(Dictionary(
             "name" -> genID(sid),
-            "fieldType" -> genType(t)
+            "fieldType" -> genType(t),
+            "fieldTypeWithPackage" -> genType(t, false, true)
           )))
       case t: EnumType =>
         TypeTemplate + Dictionary(
           "isEnum" -> v(Dictionary(
             "name" -> genID(sid),
-            "fieldType" -> genType(t)
+            "fieldType" -> genType(t),
+            "fieldTypeWithPackage" -> genType(t, false, true)
           )))
       case t: BaseType =>
         TypeTemplate + Dictionary(
@@ -132,6 +135,7 @@ trait StructTemplate {
           "isPrimitive" -> v(isPrimitive(field.fieldType)),
           "primitiveFieldType" -> genPrimitiveType(field.fieldType, mutable = false),
           "fieldType" -> genType(field.fieldType, mutable = false),
+          "fieldTypeWithPackage" -> genType(field.fieldType, mutable = false, fullyQualify = true),
           "isImported" -> v(field.fieldType match {
             case n: NamedType => n.scopePrefix.isDefined
             case _ => false

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
@@ -728,6 +728,56 @@ class ScalaGeneratorSpec extends SpecificationWithJUnit with EvalHelper with JMo
         NaughtyUnion.encode(original, protocol)
         NaughtyUnion.decode(protocol) mustEqual(original)
       }
+
+      "avoid overriding built-in types" in {
+        import thrift.`def`.default._
+        val protocol = new TBinaryProtocol(new TMemoryBuffer(10000))
+
+
+        val testRoundTrip = (original: NaughtyPrimitiveValue) => {
+          NaughtyPrimitiveValue.encode(original, protocol)
+          var decoded = NaughtyPrimitiveValue.decode(protocol)
+          decoded mustEqual(original)
+        }
+
+
+        "Fields named Byte" in {
+          val original: NaughtyPrimitiveValue = NaughtyPrimitiveValue.Byte(10.toByte)
+          original.asInstanceOf[NaughtyPrimitiveValue.Byte].Byte mustEqual(10.toByte)
+          testRoundTrip(original)
+        }
+
+        "Fields named Short" in {
+          val original: NaughtyPrimitiveValue = NaughtyPrimitiveValue.Short(20.toShort)
+          original.asInstanceOf[NaughtyPrimitiveValue.Short].Short mustEqual(20.toShort)
+          testRoundTrip(original)
+        }
+
+        "Fields named Int" in {
+          val original: NaughtyPrimitiveValue = NaughtyPrimitiveValue.Int(30)
+          original.asInstanceOf[NaughtyPrimitiveValue.Int].Int mustEqual(30)
+          testRoundTrip(original)
+        }
+
+        "Fields named Long" in {
+          val original: NaughtyPrimitiveValue = NaughtyPrimitiveValue.Long(40.toLong)
+          original.asInstanceOf[NaughtyPrimitiveValue.Long].Long mustEqual(40.toLong)
+
+          testRoundTrip(original)
+        }
+
+        "Fields named Double" in {
+          val original: NaughtyPrimitiveValue = NaughtyPrimitiveValue.Double(50.0)
+          original.asInstanceOf[NaughtyPrimitiveValue.Double].Double mustEqual(50.0)
+          testRoundTrip(original)
+        }
+
+        "Fields named Unit" in {
+          val original: NaughtyPrimitiveValue = NaughtyPrimitiveValue.Unit(60)
+          original.asInstanceOf[NaughtyPrimitiveValue.Unit].Unit mustEqual(60)
+          testRoundTrip(original)
+        }
+      }
     }
 
     "typedef relative fields" in {

--- a/scrooge-generator/src/test/thrift/standalone/naughty.thrift
+++ b/scrooge-generator/src/test/thrift/standalone/naughty.thrift
@@ -27,6 +27,15 @@ union NaughtyUnion {
 }
 
 
+union NaughtyPrimitiveValue {
+    1: byte Byte,
+    2: i16  Short,
+    3: i32  Int,
+    4: i64  Long,
+    5: double Double,
+    6: i32 Unit
+}
+
 // csl-389
 struct fooResult {
   1: string message


### PR DESCRIPTION
 	Fix the ability for unions to contain fields with names of "primitive" types, e.g. Byte, Short, Int, Long, etc.

  *  The problem here was that when generating the union, the ScalaGenerator would create case classes with the names of the union's fields.  This would cause the declaration of a variable to use tthe local case classes instead of the scala.* versions. T
  *  This fix makes a trade off of a little more code in ths fix, for the benefit of having the generated code look better.  Mainly, instead of fully-qualifying all declarations, we only do it in a few spots.
  *  Repro case is added to naughty.thrift