### PR TITLE
Automatically whitelist all idl jar dependencies

### DIFF
--- a/scrooge-maven-plugin/src/main/java/com/twitter/AbstractMavenScroogeMojo.java
+++ b/scrooge-maven-plugin/src/main/java/com/twitter/AbstractMavenScroogeMojo.java
@@ -317,7 +317,9 @@ abstract class AbstractMavenScroogeMojo extends AbstractMojo {
       // This artifact is on the whitelist directly.
       if (whitelist.contains(artifact.getArtifactId())) {
         thriftDependencies.add(artifact);
-
+      } else if ("idl".equalsIgnoreCase(artifact.getClassifier())){
+          // This artiface has an IDL classifier, whitelist it
+          thriftDependencies.add(artifact);
       // Check if this artifact is being pulled in by an idl jar that's been whitelisted
       } else {
         List<String> depTrail = artifact.getDependencyTrail();


### PR DESCRIPTION
There's a commit in the log:

e1fc595b4 "automatically whitelist all idl jar dependencies"
RB_ID=190149

Maybe I misinterpreted the intention - but it doesn't actually whitelist all IDL files. It only filters non-IDL-files from transitive dependencies.

This pull request will add support for automatically whitelisting artifacts with an "idl" classifier.
