### PR TITLE
Generated Scala code now deals correctly with default values on structs and services.

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/RHS.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/RHS.scala
@@ -11,6 +11,6 @@ case object NullLiteral extends Literal
 case class ListRHS(elems: Seq[RHS]) extends RHS
 case class SetRHS(elems: Set[RHS]) extends RHS
 case class MapRHS(elems: Seq[(RHS, RHS)]) extends RHS
-case class StructRHS(elems: Map[SimpleID, RHS]) extends RHS
+case class StructRHS(elems: Map[SimpleID, RHS], resolvedTypes: Map[SimpleID, FieldType]) extends RHS
 case class EnumRHS(enum: Enum, value: EnumField) extends RHS
 case class IdRHS(id: Identifier) extends RHS

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -65,7 +65,7 @@ class Compiler {
       val doc0 = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
 
       if (verbose) println("+ Compiling %s".format(inputFile))
-      val resolvedDoc = TypeResolver(allowStructRHS = isJava)(doc0) // TODO: THRIFT-54
+      val resolvedDoc = TypeResolver()(doc0) // TODO: THRIFT-54
       val generator = Generator(
         language,
         resolvedDoc.resolver.includeMap,

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
@@ -30,10 +30,10 @@ object JavaGeneratorFactory extends GeneratorFactory {
   ): ThriftGenerator = new JavaGenerator(includeMap, defaultNamespace, generationDate)
 }
 
-class JavaGenerator(
-  val includeMap: Map[String, ResolvedDocument],
-  val defaultNamespace: String,
-  val generationDate: String
+case class JavaGenerator(
+  includeMap: Map[String, ResolvedDocument],
+  defaultNamespace: String,
+  generationDate: String
 ) extends Generator with ThriftGenerator {
 
   val fileExtension = ".java"
@@ -114,6 +114,10 @@ class JavaGenerator(
         "Utilities.makeTuple(" + genConstant(k).toData + ", " + genConstant(v).toData + ")"
     } mkString (", ")) + ")"
     codify(code)
+  }
+
+  def genStruct(fieldID: SimpleID, fieldType: FieldType, elems: Map[SimpleID, RHS], typeMappings: Map[SimpleID, FieldType], mutable: Boolean = false): CodeFragment = {
+    genDefaultValue(fieldType, mutable)
   }
 
   def genEnum(enum: EnumRHS): CodeFragment =

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
@@ -31,11 +31,11 @@ object ScalaGeneratorFactory extends GeneratorFactory {
   ): ThriftGenerator = new ScalaGenerator(includeMap, defaultNamespace, generationDate, experimentFlags)
 }
 
-class ScalaGenerator(
-  val includeMap: Map[String, ResolvedDocument],
-  val defaultNamespace: String,
-  val generationDate: String,
-  val experimentFlags: Seq[String]
+case class ScalaGenerator(
+  includeMap: Map[String, ResolvedDocument],
+  defaultNamespace: String,
+  generationDate: String,
+  experimentFlags: Seq[String]
 ) extends Generator with ThriftGenerator {
 
   val fileExtension = ".scala"
@@ -135,6 +135,11 @@ class ScalaGenerator(
 
   def genEnum(enum: EnumRHS): CodeFragment =
     genID(enum.value.sid.toTitleCase.addScope(enum.enum.sid.toTitleCase))
+
+  def genStruct(fieldID: SimpleID, fieldType: FieldType, elems: Map[SimpleID, RHS], typeMappings: Map[SimpleID, FieldType], mutable: Boolean = false): CodeFragment = {
+    val code = fieldID.name + "(" + elems.toList.map(pair => pair._1.name + " = " + genConstant(pair._2, mutable, typeMappings.get(pair._1)).toData).mkString(",") + ")"
+    codify(code)
+  }
 
   override def genDefaultValue(fieldType: FieldType, mutable: Boolean = false): CodeFragment = {
     val code = fieldType match {

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
@@ -105,13 +105,19 @@ class ThriftParser(
   // ride hand side (RHS)
 
   lazy val rhs: Parser[RHS] = {
-    numberLiteral | stringLiteral | listOrMapRHS | mapRHS | idRHS |
+    boolLiteral | numberLiteral | stringLiteral | listOrMapRHS | mapRHS | idRHS | 
       failure("constant expected")
   }
 
   lazy val intConstant = "[-+]?\\d+(?!\\.)".r ^^ {
     x => IntLiteral(x.toLong)
   }
+
+  lazy val trueLiteral = "true" ^^^ BoolLiteral(true)
+
+  lazy val falseLiteral = "false" ^^^ BoolLiteral(false)
+
+  lazy val boolLiteral = trueLiteral | falseLiteral
 
   lazy val numberLiteral = "[-+]?\\d+(\\.\\d+)?([eE][-+]?\\d+)?".r ^^ {
     x =>
@@ -194,7 +200,8 @@ class ThriftParser(
         val transformedVal = ftype match {
           case TBool => value map {
             case IntLiteral(0) => BoolLiteral(false)
-            case _ => BoolLiteral(true)
+            case IntLiteral(_) => BoolLiteral(true)
+            case other => other
           }
           case _ => value
         }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
@@ -25,10 +25,10 @@ object ApacheJavaGeneratorFactory extends GeneratorFactory {
   ): ThriftGenerator = new ApacheJavaGenerator(includeMap, defaultNamespace)
 }
 
-class ApacheJavaGenerator(
+case class ApacheJavaGenerator(
     includeMap: Map[String, ResolvedDocument],
     defaultNamespace: String,
-    val genHashcode: Boolean = true // Defaulting to true for pants.
+    genHashcode: Boolean = true // Defaulting to true for pants.
   ) extends ThriftGenerator {
   var counter = 0
 

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
@@ -215,6 +215,15 @@ class ScalaGeneratorSpec extends JMockSpec with EvalHelper {
       ))
     }
 
+    "assign complex defaults" in {_ =>
+      val innerDefaultedValue = InnerDefaultedValue(firstBoolean = true, secondBoolean = false, innerStringValue = "innerDefaultedStringValue")
+      thrift.test.StructWithDefaults() must be(StructWithDefaults(stringValue = "defaultedStringValue", intValue = 90909, innerValue = innerDefaultedValue))
+    }
+
+    "assign simple defaults" in {_ =>
+      SimpleDefaults() must be (SimpleDefaults(requiredTrueBool = true, requiredFalseBool = false, optionalTrueBool = true, optionalFalseBool = false))
+    }
+
     "basic structs" should {
       "ints" should {
         "read" in { cycle => import cycle._

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
@@ -80,7 +80,25 @@ class ThriftParserSpec extends Spec {
           Field(-1, SimpleID("id"), "id", TI32, None, Requiredness.Optional),
           Field(3, SimpleID("name"), "name", TString, Some(StringLiteral("cat")), Requiredness.Required)
         ), Seq(Field(1, SimpleID("ex"), "ex", ReferenceType(Identifier("Exception")), None, Requiredness.Default)), None))
-    }
+      parser.parse(
+        """list<string> get_tables(optional i32 id, /**DOC*/3: required User user = {"name": "dave", "yesOrNo": true}) throws (1: Exception ex);""",
+        parser.function) must be(
+          Function(
+            SimpleID("get_tables"),
+            "get_tables",
+            ListType(TString,None),
+            List(
+              Field(-1,SimpleID("id"),"id",TI32,None,Requiredness.Optional,Map(),Map()), 
+              Field(3,SimpleID("user"),"user",ReferenceType(SimpleID("User")),Some(MapRHS(List(
+                (StringLiteral("name"),StringLiteral("dave")),
+                (StringLiteral("yesOrNo"),BoolLiteral(true))
+              ))),Requiredness.Required,Map(),Map())
+            ),
+            List(Field(1,SimpleID("ex"),"ex",ReferenceType(SimpleID("Exception")),None,Requiredness.Default,Map(),Map())),
+            None
+          )
+        )
+     }
 
     "const" in {
       parser.parse("/** COMMENT */ const string name = \"Columbo\"", parser.definition) must be(ConstDefinition(SimpleID("name"),

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
@@ -22,7 +22,7 @@ class ApacheJavaGeneratorSpec extends Spec {
     val importer = Importer(Seq("src/test/resources/test_thrift", "scrooge-generator/src/test/resources/test_thrift"))
     val parser = new ThriftParser(importer, true)
     val doc = parser.parse(str, parser.document)
-    TypeResolver(allowStructRHS = true)(doc).document
+    TypeResolver()(doc).document
   }
 
   def getGenerator(doc0: Document, genHashcode: Boolean = false) = {

--- a/scrooge-generator/src/test/thrift/standalone/test.thrift
+++ b/scrooge-generator/src/test/thrift/standalone/test.thrift
@@ -523,6 +523,29 @@ struct LargeDeltas {
   4000: list<i32> big_numbers
 }
 
+struct SimpleDefaults {
+  1:required bool requiredTrueBool = true;
+  2:required bool requiredFalseBool = false;
+  3:optional bool optionalTrueBool = true;
+  4:optional bool optionalFalseBool = false;
+}
+
+struct InnerDefaultedValue {
+  1:bool firstBoolean;
+  2:bool secondBoolean;
+  3:string innerStringValue;
+}
+
+struct StructWithDefaults {
+  1:string stringValue = "defaultedStringValue"
+  2:i32 intValue = 90909
+  3:InnerDefaultedValue innerValue = {"firstBoolean": true, "secondBoolean": false, "innerStringValue": "innerDefaultedStringValue"}
+}
+
+service ServiceWithDefaults {
+  void defaultedService(1:StructWithDefaults structWithDefaults = {"stringValue": "anotherDefaultedStringValue"}, 2:bool firstBoolParameter = true, 3:bool secondBoolParameter = false, 4:string stringParameter = "stringParameterDefault");
+}
+
 service ReadOnlyService {
   string getName()
 }


### PR DESCRIPTION
At the very least this should fix: http://github.com/twitter/scrooge/issues/99

In the process of doing so I've found a couple of other issues around defaults like false being set to true for booleans and the parser itself didn't handle boolean literals.