### PR TITLE
Upgraded scopt from 2.1.0 to 3.2.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -168,7 +168,7 @@ object Scrooge extends Build {
       util("core"),
       util("codec"),
       "org.apache.thrift" % "libthrift" % "0.8.0",
-      "com.github.scopt" %% "scopt" % "2.1.0",
+      "com.github.scopt" %% "scopt" % "3.2.0",
       "com.novocode" % "junit-interface" % "0.8" % "test->default",
       "com.github.spullara.mustache.java" % "compiler" % "0.8.12",
       "org.codehaus.plexus" % "plexus-utils" % "1.5.4",

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Main.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Main.scala
@@ -36,82 +36,110 @@ object Main {
       buildProperties.load(resource.openStream)
     }
 
-    val parser = new OptionParser("scrooge") {
-      help(None, "help", "show this help screen")
+    val parser = new OptionParser[Compiler]("scrooge") {
+      help("help") text("show this help screen")
 
-      opt("V", "version", "print version and quit", {
-        println("scrooge " + buildProperties.getProperty("version", "0.0"))
-        println("    build " + buildProperties.getProperty("build_name", "unknown"))
-        println("    git revision " + buildProperties.getProperty("build_revision", "unknown"))
-        System.exit(0)
-        ()
-      })
+      opt[Unit]('V', "version") action { (_, c) => {
+          println("scrooge " + buildProperties.getProperty("version", "0.0"))
+          println("    build " + buildProperties.getProperty("build_name", "unknown"))
+          println("    git revision " + buildProperties.getProperty("build_revision", "unknown"))
+          System.exit(0)
+          c
+        }} text("print version and quit")
 
-      opt("v", "verbose", "log verbose messages about progress", { compiler.verbose = true; () })
+      opt[Unit]('v', "verbose") action { (_, c) => {
+          c.verbose = true
+          c
+        }} text("log verbose messages about progress")
 
-      opt("d", "dest", "<path>",
-        "write generated code to a folder (default: %s)".format(compiler.defaultDestFolder), { x: String =>
-          compiler.destFolder = x
-        })
+      opt[String]('d', "dest") valueName("<path>") action { (d, c) => {
+          c.destFolder = d
+          c
+        }} text("write generated code to a folder (default: %s)".format(compiler.defaultDestFolder))
 
-      opt(None, "import-path", "<path>", "[DEPRECATED] path(s) to search for included thrift files (may be used multiple times)",
-        { path: String => compiler.includePaths ++= path.split(File.pathSeparator); () })
+      opt[String]("import-path") valueName("<path>") action { (path, c) => {
+          c.includePaths ++= path.split(File.pathSeparator)
+          c
+        }} text("[DEPRECATED] path(s) to search for included thrift files (may be used multiple times)")
 
-      opt("i", "include-path", "<path>", "path(s) to search for included thrift files (may be used multiple times)",
-        { path: String => compiler.includePaths ++= path.split(File.pathSeparator); () })
+      opt[String]('i', "include-path") valueName("<path>") action { (path, c) => { 
+          c.includePaths ++= path.split(File.pathSeparator)
+          c
+        }} text("path(s) to search for included thrift files (may be used multiple times)")
 
-      opt("n", "namespace-map", "<oldname>=<newname>", "map old namespace to new (may be used multiple times)",
-        { mapping: String =>
+      opt[String]('n', "namespace-map") valueName("<oldname>=<newname>") action { (mapping, c) =>
           mapping.split("=") match {
-            case Array(from, to) => compiler.namespaceMappings(from) = to
+            case Array(from, to) => {
+              c.namespaceMappings(from) = to
+              c
+            }
           }
-          ()
-        })
+        } text("map old namespace to new (may be used multiple times)")
 
-      opt(None, "default-java-namespace", "<name>",
-        "Use <name> as default namespace if the thrift file doesn't define its own namespace. " +
-          "If this option is not specified either, then use \"thrift\" as default namespace",
-        { name: String => compiler.defaultNamespace = name })
+      opt[String]("default-java-namespace") valueName("<name>") action { (name, c) => {
+          c.defaultNamespace = name
+          c
+        }} text("Use <name> as default namespace if the thrift file doesn't define its own namespace. " +
+          "If this option is not specified either, then use \"thrift\" as default namespace")
 
-      opt("disable-strict", "issue warnings on non-severe parse errors instead of aborting",
-        { compiler.strict = false; () })
+      opt[Unit]("disable-strict") action { (_, c) => {
+          c.strict = false
+          c
+        }} text("issue warnings on non-severe parse errors instead of aborting")
 
-      opt(None, "gen-file-map", "<path>", "generate map.txt in the destination folder to specify the mapping from input thrift files to output Scala/Java files",
-        { path: String => compiler.fileMapPath = Some(path); () })
+      opt[String]("gen-file-map") valueName("<path>") action { (path, c) => {
+          c.fileMapPath = Some(path)
+          c
+        }} text("generate map.txt in the destination folder to specify the mapping from input thrift files to output Scala/Java files")
 
-      opt("dry-run",
-        "parses and validates source thrift files, reporting any errors, but" +
+      opt[Unit]("dry-run") action { (_, c) => {
+          c.dryRun = true
+          c
+        }} text("parses and validates source thrift files, reporting any errors, but" +
           " does not emit any generated source code.  can be used with " +
-          "--gen-file-mapping to get the file mapping",
-        { compiler.dryRun = true; () })
+          "--gen-file-mapping to get the file mapping")
 
-      opt("s", "skip-unchanged", "Don't re-generate if the target is newer than the input",
-        { compiler.skipUnchanged = true; () })
+      opt[Unit]('s', "skip-unchanged") action { (_, c) => {
+          c.skipUnchanged = true
+          c
+        }} text("Don't re-generate if the target is newer than the input")
 
-      opt("l", "language", "name of language to generate code in ('experimental-java' and 'scala' are currently supported)",
-        { languageString: String =>
+      opt[String]('l', "language") action { (languageString, c) =>
           if (Generator.languages.toList contains languageString.toLowerCase) {
-            compiler.language = languageString
+            c.language = languageString
+            c
           } else {
             println("language option %s not supported".format(languageString))
             System.exit(0)
+            c
           }
-          ()
-        })
+        } text("name of language to generate code in ('experimental-java' and 'scala' are currently supported)")
 
-      opt(None, "experiment-flag", "<flag>",
-        "[EXPERIMENTAL] DO NOT USE FOR PRODUCTION. This is meant only for enabling/disabling features for benchmarking",
-        { flag: String => compiler.experimentFlags += flag; () })
+      opt[String]("experiment-flag") valueName("<flag>") action { (flag, c) => {
+          c.experimentFlags += flag
+          c
+        }} text("[EXPERIMENTAL] DO NOT USE FOR PRODUCTION. This is meant only for enabling/disabling features for benchmarking")
 
-      opt("scala-warn-on-java-ns-fallback", "Print a warning when the scala generator falls back to the java namespace",
-        { compiler.scalaWarnOnJavaNSFallback = true; () })
+      opt[Unit]("scala-warn-on-java-ns-fallback") action { (_, c) => {
+          c.scalaWarnOnJavaNSFallback = true
+          c
+        }} text("Print a warning when the scala generator falls back to the java namespace")
 
-      opt("finagle", "generate finagle classes",
-        { compiler.flags += WithFinagle; () })
+      opt[Unit]("finagle") action { (_, c) => {
+          c.flags += WithFinagle
+          c
+        }} text("generate finagle classes")
 
-      arglist("<files...>", "thrift files to compile", { compiler.thriftFiles += _ })
+      arg[String]("<files...>") unbounded() action { (files, c) => {
+          c.thriftFiles += files
+          c
+        }} text("thrift files to compile")
     }
-    parser.parse(args)
+    parser.parse(args, compiler) map { c =>
+      true
+    } getOrElse {
+      false
+    }
   }
 
   def isUnchanged(file: File, sourceLastModified: Long): Boolean = {


### PR DESCRIPTION
This patch contains
- scopt dependency upgrade from 2.1.0 to 3.2.0 and
- accompanying migration of scrooge-generator CLI argument parsing to new scopt

Old scopt version in scrooge, and new one in scalastyle-sbt-plugin v0.4.0 was causing issues like [this](https://github.com/scalastyle/scalastyle-sbt-plugin/issues/15)