### PR TITLE
Display the missing field name

### DIFF
--- a/scrooge-generator/src/main/resources/scalagen/struct.scala
+++ b/scrooge-generator/src/main/resources/scalagen/struct.scala
@@ -139,7 +139,7 @@ object {{StructName}} extends ThriftStructCodec3[{{StructName}}] {
 
 {{#fields}}
 {{#required}}
-    if (!{{gotName}}) throw new TProtocolException("Required field '{{StructNameForWire}}' was not found in serialized data for struct {{StructName}}")
+    if (!{{gotName}}) throw new TProtocolException("Required field '{{fieldName}}' was not found in serialized data for struct {{StructName}}")
 {{/required}}
 {{/fields}}
     new {{InstanceClassName}}(


### PR DESCRIPTION
It currently displays the name of the struct which is not very helpful.
