### PR TITLE
add is required to ThriftStructFieldInfo

### DIFF
--- a/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftStructMetaData.scala
+++ b/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftStructMetaData.scala
@@ -92,6 +92,7 @@ final class ThriftStructField[T <: ThriftStruct](val tfield: TField, val method:
 final class ThriftStructFieldInfo(
   val tfield: TField,
   val isOptional: Boolean,
+  val isRequired: Boolean,
   val manifest: Manifest[_],
   val keyManifest: scala.Option[Manifest[_]],
   val valueManifest: scala.Option[Manifest[_]],
@@ -105,6 +106,7 @@ final class ThriftStructFieldInfo(
   def this(
     tfield: TField,
     isOptional: Boolean,
+    isRequired: Boolean,
     manifest: Manifest[_],
     keyManifest: scala.Option[Manifest[_]],
     valueManifest: scala.Option[Manifest[_]]
@@ -112,6 +114,7 @@ final class ThriftStructFieldInfo(
     this(
       tfield,
       isOptional,
+      isRequired,
       manifest,
       keyManifest,
       valueManifest,

--- a/scrooge-generator/src/main/resources/scalagen/struct.scala
+++ b/scrooge-generator/src/main/resources/scalagen/struct.scala
@@ -35,6 +35,7 @@ object {{StructName}} extends ThriftStructCodec3[{{StructName}}] {
     new ThriftStructFieldInfo(
       {{fieldConst}},
       {{optional}},
+      {{required}},
       {{fieldConst}}Manifest,
 {{#fieldKeyType}}
       Some(implicitly[Manifest[{{fieldKeyType}}]]),

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/ThriftStructMetaDataSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/ThriftStructMetaDataSpec.scala
@@ -81,6 +81,13 @@ class ThriftStructMetaDataSpec extends Spec {
     // All of the OneOfEachOptional fields are optional:
     OneOfEachOptional.fieldInfos.foreach { fieldInfo =>
       fieldInfo.isOptional must be(true)
+      fieldInfo.isRequired must be(false)
+    }
+
+    //All of the OneOfEachWithDefault fields are default:
+    OneOfEachWithDefault.fieldInfos.foreach { fieldInfo =>
+      fieldInfo.isRequired must be(false)
+      fieldInfo.isOptional must be(false)
     }
   }
 


### PR DESCRIPTION
This is for better reflection. Since Thrift not only has Optional and Required, but also Default for requirement type of a field.

So if a field is not optional and not required, then it can be considered as Default.
