### PR TITLE
Fix //-style comments on Windows

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
@@ -34,11 +34,11 @@ class ThriftParser(
 ) extends RegexParsers {
 
 
-  //                            1    2        3                   4         4a    4b 4c       4d
-  override val whiteSpace = """(\s+|(//.*\n)|(#([^@\n][^\n]*)?\n)|(/\*[^\*]([^\*]+|\n|\*(?!/))*\*/))+""".r
+  //                            1    2           3                              4         4a    4b    4c       4d
+  override val whiteSpace = """(\s+|(//.*\r?\n)|(#([^@\r?\n][^(\r?\n)]*)?\r?\n)|(/\*[^\*]([^\*]+|\r?\n|\*(?!/))*\*/))+""".r
   // 1: whitespace, 1 or more
-  // 2: leading // followed by anything 0 or more, until \n
-  // 3: leading #  then NOT a @ followed by anything 0 or more, until \n
+  // 2: leading // followed by anything 0 or more, until newline
+  // 3: leading #  then NOT a @ followed by anything 0 or more, until newline
   // 4: leading /* then NOT a *, then...
   // 4a:  not a *, 1 or more times
   // 4b:  OR a newline

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
@@ -8,11 +8,22 @@ class ThriftParserSpec extends Spec {
   "ThriftParser" should {
     val parser = new ThriftParser(NullImporter, true)
 
+    val commentTestSources = Seq(
+      "  300  ",
+      "  // go away.\n 300",
+      "  /*\n   * go away.\n   */\n 300",
+      "# hello\n 300"
+    )
+
+    def verifyCommentParsing(source: String) =
+      parser.parse(source, parser.rhs) must be(IntLiteral(300))
+
     "comments" in {
-      parser.parse("  300  ", parser.rhs) must be( IntLiteral(300))
-      parser.parse("  // go away.\n 300", parser.rhs) must be( IntLiteral(300))
-      parser.parse("  /*\n   * go away.\n   */\n 300", parser.rhs) must be(IntLiteral(300))
-      parser.parse("# hello\n 300", parser.rhs) must be(IntLiteral(300))
+      commentTestSources.foreach(verifyCommentParsing)
+    }
+
+    "comments with Windows-style carriage return" in {
+      commentTestSources.map(_.replace("\n","\r\n")).foreach(verifyCommentParsing)
     }
 
     "double-quoted strings" in {


### PR DESCRIPTION
Don't match \n, but match \r?\n, so we can match Windows-style endlines \r\n.
Would be great if you could test this on Linux before merging (I only use Windows)
