### PR TITLE
Scala 2.11 build for Scrooge-core

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,7 +81,7 @@ object Scrooge extends Build {
     otherResolvers += m2Repo,
 
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % (if ((scalaVersion in Compile).value.startsWith("2.11")) "2.2.1" else "1.9.2") % "test",
+      "org.scalatest" %% "scalatest" % (if ((scalaVersion in Compile).value.startsWith("2.11")) "2.1.3" else "1.9.1") % "test",
       "junit" % "junit" % "4.8.1" % "test"
     ),
     resolvers += "twitter-repo" at "http://maven.twttr.com",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ import net.virtualvoid.sbt.cross.CrossPlugin
 
 object Scrooge extends Build {
   val libVersion = "3.16.3"
-  val utilVersion = "6.19.0"
+  val utilVersion = "6.20.0"
   val finagleVersion = "6.20.0"
 
   def util(which: String) = "com.twitter" %% ("util-"+which) % utilVersion

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -81,7 +81,7 @@ object Scrooge extends Build {
     otherResolvers += m2Repo,
 
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "1.9.1" % "test",
+      "org.scalatest" %% "scalatest" % (if ((scalaVersion in Compile).value.startsWith("2.11")) "2.2.1" else "1.9.2") % "test",
       "junit" % "junit" % "4.8.1" % "test"
     ),
     resolvers += "twitter-repo" at "http://maven.twttr.com",
@@ -194,7 +194,8 @@ object Scrooge extends Build {
     name := "scrooge-core",
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.8.0" % "provided"
-    )
+    ),
+    crossScalaVersions += "2.11.2"
   )
 
   lazy val scroogeRuntime = Project(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.5


### PR DESCRIPTION
As requested in #129 and discussed with @mosesn in twitter/finagle#290 here's the Scala 2.11 support for scrooge-core.

As in the ScalaTest migration guide: http://www.scalatest.org/user_guide/migrating_to_20 I've updated the ScalaTest to 1.9.2 for Scala 2.9.x and 2.10.x and as there were no deprecations updated the dependency to 2.2.1 (newest stable version) for Scala 2.11.x.

As soon as there is a finagle branch cross compiled for Scala 2.11 I'll be able to work on all the other parts of Scrooge to support Scala 2.11.