### PR TITLE
Address or suppress warnings.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -75,7 +75,13 @@ object Scrooge extends Build {
     ),
 
     publishM2Configuration <<= (packagedArtifacts, checksums in publish, ivyLoggingLevel) map { (arts, cs, level) =>
-      Classpaths.publishConfig(arts, None, resolverName = m2Repo.name, checksums = cs, logging = level)
+      Classpaths.publishConfig(
+        artifacts = arts,
+        ivyFile = None,
+        resolverName = m2Repo.name,
+        checksums = cs,
+        logging = level,
+        overwrite = true)
     },
     publishM2 <<= Classpaths.publishTask(publishM2Configuration, deliverLocal),
     otherResolvers += m2Repo,
@@ -88,7 +94,7 @@ object Scrooge extends Build {
 
     scalacOptions ++= Seq("-encoding", "utf8"),
     scalacOptions += "-deprecation",
-    javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
+    javacOptions ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:unchecked"),
     javacOptions in doc := Seq("-source", "1.6"),
 
     // Sonatype publishing

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
+scalacOptions += "-deprecation"
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")
 
 addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.1")

--- a/scrooge-runtime/src/main/java/com/twitter/scrooge/Option.java
+++ b/scrooge-runtime/src/main/java/com/twitter/scrooge/Option.java
@@ -14,6 +14,7 @@ public abstract class Option<A> {
     }
   }
 
+  @SuppressWarnings("unchecked")
   public static <A> Option<A> none() {
     return (Option<A>) NONE;
   }
@@ -43,6 +44,7 @@ public abstract class Option<A> {
       return true;
     }
 
+    @SuppressWarnings("unchecked")
     public boolean equals(Object other) {
       if (!(other instanceof Some)) return false;
       Some<A> that = (Some<A>) other;

--- a/scrooge-runtime/src/main/java/com/twitter/scrooge/Utilities.java
+++ b/scrooge-runtime/src/main/java/com/twitter/scrooge/Utilities.java
@@ -21,10 +21,12 @@ public class Utilities {
     }
   }
 
+  @SafeVarargs
   public static <T> List<T> makeList(T... elements) {
     return Arrays.asList(elements);
   }
 
+  @SafeVarargs
   public static <A, B> Map<A, B> makeMap(Tuple<A, B>... elements) {
     Map<A, B> map = new HashMap<A, B>();
     for (Tuple<A, B> element : elements) {
@@ -33,6 +35,7 @@ public class Utilities {
     return map;
   }
 
+  @SafeVarargs
   public static <T> Set<T> makeSet(T... elements) {
     Set<T> set = new HashSet<T>();
     for (T element : elements) {


### PR DESCRIPTION
Add `-deprecation` to `scalacOptions`, and `-Xlint:unchecked` to `javacOptions`, so we see details of warnings.

For _Classpaths.publishConfig_ is deprecated*, set `overwrite = true`.

For _unchecked cast_, add `@SuppressWarnings("unchecked")`.

For _Possible heap pollution from parameterized vararg type T_, add `@SafeVarargs`.
