### PR TITLE
Revert "[split] Revert "upload the scrooge sbt plugin to bintray""

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,7 @@
 import sbt._
 import Keys._
+import bintray.Plugin._
+import bintray.Keys._
 import com.typesafe.sbt.SbtSite.site
 import com.typesafe.sbt.site.SphinxSupport.Sphinx
 import net.virtualvoid.sbt.cross.CrossPlugin
@@ -145,7 +147,7 @@ object Scrooge extends Build {
       "org.mockito" % "mockito-all" % "1.9.0" % "test"
     )
   )
-  
+
   lazy val crossBuildSettings: Seq[Setting[_]] = CrossPlugin.crossBuildingSettings ++ CrossBuilding.scriptedSettings ++ Seq(
     CrossBuilding.crossSbtVersions := Seq("0.12", "0.13")
   )
@@ -239,11 +241,16 @@ object Scrooge extends Build {
   lazy val scroogeSbtPlugin = Project(
     id = "scrooge-sbt-plugin",
     base = file("scrooge-sbt-plugin"),
-    settings = Project.defaultSettings ++ 
+    settings = Project.defaultSettings ++
       sharedSettings ++
-      crossBuildSettings
+      crossBuildSettings ++
+      bintrayPublishSettings
   ).settings(
-    sbtPlugin := true
+    sbtPlugin := true,
+    publishMavenStyle := false,
+    repository in bintray := "sbt-plugins",
+    licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+    bintrayOrganization in bintray := Some("twittercsl")
   ).dependsOn(scroogeGenerator)
 
   lazy val scroogeLinter = Project(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,9 @@
+resolvers += Resolver.url(
+  "bintray-sbt-plugin-releases",
+   url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")
 
 addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.1")


### PR DESCRIPTION
Looks like this got reverted because of a failed travis build https://travis-ci.org/twitter/scrooge/builds/23263652

I think travis failed for a different reason (and we are fixing that). Reverting the revert to bring back sbt plugin publishing.

This reverts commit bd463d9a581bdce48c37754b866c4bbd04b8fb21.
