### PR TITLE
Multithreaded scrooge-generator

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -69,8 +69,8 @@ object Scrooge extends Build {
   val sharedSettings = Seq(
     version := libVersion,
     organization := "com.twitter",
-    crossScalaVersions := Seq("2.9.2", "2.10.4"),
-    scalaVersion := "2.9.2",
+    crossScalaVersions := Seq("2.10.4"),
+    scalaVersion := "2.10.4",
 
     resolvers ++= Seq(
       "sonatype-public" at "https://oss.sonatype.org/content/groups/public"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -182,6 +182,7 @@ object Scrooge extends Build {
       "org.codehaus.plexus" % "plexus-utils" % "1.5.4",
       "com.google.code.findbugs" % "jsr305" % "1.3.9",
       "commons-cli" % "commons-cli" % "1.2",
+      "commons-io" % "commons-io" % "2.4",
       finagle("core"),
       finagle("thrift") % "test"
     )

--- a/scrooge-generator/pom.xml
+++ b/scrooge-generator/pom.xml
@@ -135,6 +135,11 @@
       <artifactId>commons-cli</artifactId>
       <version>1.2</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/scrooge-generator/src/main/resources/javagen/consts.java
+++ b/scrooge-generator/src/main/resources/javagen/consts.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 @javax.annotation.Generated(value = "com.twitter.scrooge.Compiler")
-public final class Constants {
+public final class {{basename}}Constants {
 {{#constants}}
   {{docstring}}
   public static final {{fieldType}} {{name}} = {{value}};

--- a/scrooge-generator/src/main/resources/scalagen/consts.scala
+++ b/scrooge-generator/src/main/resources/scalagen/consts.scala
@@ -1,7 +1,7 @@
 package {{package}}
 
 @javax.annotation.Generated(value = Array("com.twitter.scrooge.Compiler"))
-object Constants {
+object {{basename}}Constants {
 {{#constants}}
   {{docstring}}
   val {{name}}: {{fieldType}} = {{value}}

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Document.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Document.scala
@@ -1,6 +1,5 @@
 package com.twitter.scrooge.ast
 
-
 case class Document(headers: Seq[Header], defs: Seq[Definition],
   filename: Option[String] = None) extends DocumentNode {
   def namespace(language: String): Option[Identifier] = {

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Document.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Document.scala
@@ -1,6 +1,6 @@
 package com.twitter.scrooge.ast
 
-case class Document(headers: Seq[Header], defs: Seq[Definition]) extends DocumentNode {
+case class Document(headers: Seq[Header], defs: Seq[Definition], filename: Option[String]) extends DocumentNode {
   def namespace(language: String): Option[Identifier] = {
     (headers collect {
       // first try to find language specific namespace scope

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Document.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Document.scala
@@ -1,6 +1,8 @@
 package com.twitter.scrooge.ast
 
-case class Document(headers: Seq[Header], defs: Seq[Definition], filename: Option[String]) extends DocumentNode {
+
+case class Document(headers: Seq[Header], defs: Seq[Definition],
+  filename: Option[String] = None) extends DocumentNode {
   def namespace(language: String): Option[Identifier] = {
     (headers collect {
       // first try to find language specific namespace scope

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -56,7 +56,7 @@ class Compiler {
     val importer = Importer(new File(".")) +: Importer(includePaths)
 
     // compile
-    for (inputFile <- thriftFiles) {
+    thriftFiles.par.foreach { inputFile =>
       val isJava = language.equals("java")
       val isScala = language.equals("scala")
       val isLint = language.equals("lint")

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -38,6 +38,7 @@ class Compiler {
   var language: String = "scala"
   var defaultNamespace: String = "thrift"
   var scalaWarnOnJavaNSFallback: Boolean = false
+  var multithreaded: Boolean = true
 
   def run() {
     // if --gen-file-map is specified, prepare the map file.
@@ -60,7 +61,12 @@ class Compiler {
     val rhsStructs = isJava || isScala
 
     // compile
-    thriftFiles.par.foreach { inputFile =>
+    val inputs = if (multithreaded)
+      thriftFiles.par
+    else
+      thriftFiles
+
+    inputs.foreach { inputFile =>
       val parser = new ThriftParser(importer, strict, defaultOptional = isJava, skipIncludes = false)
       val doc0 = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -55,13 +55,13 @@ class Compiler {
 
     val importer = Importer(new File(".")) +: Importer(includePaths)
 
+    val isJava = language.equals("java")
+    val isScala = language.equals("scala")
+    val rhsStructs = isJava || isScala
+
     // compile
     thriftFiles.par.foreach { inputFile =>
-      val isJava = language.equals("java")
-      val isScala = language.equals("scala")
-      val isLint = language.equals("lint")
-      val rhsStructs = isJava || isScala
-      val parser = new ThriftParser(importer, strict, defaultOptional = isJava, skipIncludes = isLint)
+      val parser = new ThriftParser(importer, strict, defaultOptional = isJava, skipIncludes = false)
       val doc0 = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
 
       if (verbose) println("+ Compiling %s".format(inputFile))

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Main.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Main.scala
@@ -76,6 +76,9 @@ object Main {
       opt("disable-strict", "issue warnings on non-severe parse errors instead of aborting",
         { compiler.strict = false; () })
 
+      opt("singlethreaded", "run scrooge-generator sequentially over multiple input files (default is parallel)",
+        { compiler.multithreaded = false; () })
+
       opt(None, "gen-file-map", "<path>", "generate map.txt in the destination folder to specify the mapping from input thrift files to output Scala/Java files",
         { path: String => compiler.fileMapPath = Some(path); () })
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ConstsTemplate.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ConstsTemplate.scala
@@ -7,10 +7,12 @@ import com.twitter.scrooge.ast.{Identifier, ConstDefinition}
 trait ConstsTemplate {
   self: Generator =>
   def constDict(
+    basename: String,
     namespace: Identifier,
     consts: Seq[ConstDefinition]
   ): Dictionary = Dictionary(
     "package" -> genID(namespace),
+    "basename" -> codify(basename),
     "constants" -> v(consts map {
       c =>
         Dictionary(

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
@@ -90,7 +90,6 @@ trait Generator
   /******************** helper functions ************************/
   private[this] def namespacedFolder(destFolder: File, namespace: String, dryRun: Boolean) = {
     val file = new File(destFolder, namespace.replace('.', File.separatorChar))
-
     if (!dryRun) file.mkdirs()
     file
   }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
@@ -25,6 +25,7 @@ import com.twitter.scrooge.java_generator.ApacheJavaGeneratorFactory
 import scala.collection.JavaConverters._
 import com.twitter.scrooge.frontend.{ScroogeInternalException, ResolvedDocument}
 import com.twitter.finagle.util.LoadService
+import org.apache.commons.io.FilenameUtils
 
 abstract sealed class ServiceOption
 
@@ -342,10 +343,10 @@ trait Generator
     }
 
     if (doc.consts.nonEmpty) {
-      val filename = ""//doc.filename.getOrElse("").replaceAll(".thrift", "")
-      val file = new File(packageDir, filename + "Constants" + fileExtension)
+      val basename = FilenameUtils.getBaseName(doc.filename.getOrElse(""))
+      val file = new File(packageDir, basename + "Constants" + fileExtension)
       if (!dryRun) {
-        val dict = constDict(namespace, doc.consts)
+        val dict = constDict(basename, namespace, doc.consts)
         writeFile(file, templates.header, templates("consts").generate(dict))
       }
       generatedFiles += file

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
@@ -89,6 +89,7 @@ trait Generator
   /******************** helper functions ************************/
   private[this] def namespacedFolder(destFolder: File, namespace: String, dryRun: Boolean) = {
     val file = new File(destFolder, namespace.replace('.', File.separatorChar))
+
     if (!dryRun) file.mkdirs()
     file
   }
@@ -341,7 +342,8 @@ trait Generator
     }
 
     if (doc.consts.nonEmpty) {
-      val file = new File(packageDir, "Constants" + fileExtension)
+      val filename = ""//doc.filename.getOrElse("").replaceAll(".thrift", "")
+      val file = new File(packageDir, filename + "Constants" + fileExtension)
       if (!dryRun) {
         val dict = constDict(namespace, doc.consts)
         writeFile(file, templates.header, templates("consts").generate(dict))

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
@@ -435,8 +435,6 @@ class ThriftParser(
       throw new FileNotFoundException(filename)
     }
 
-    val newImporter = contents.importer
-
     // one thrift file can be included in another and referenced like this:
     // list<includedthriftfilenamehere.Request> requests
     //

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
@@ -27,7 +27,9 @@ class ThriftParser(
     importer: Importer,
     strict: Boolean,
     defaultOptional: Boolean = false,
-    skipIncludes: Boolean = false)
+    skipIncludes: Boolean = false,
+    filename: Option[String] = None
+)
   extends RegexParsers {
 
   import com.twitter.scrooge.ast._
@@ -368,19 +370,20 @@ class ThriftParser(
   // document
 
   lazy val document: Parser[Document] = rep(header) ~ rep(definition) <~ opt(comments) ^^ {
-    case hs ~ ds => Document(hs, ds)
+    case hs ~ ds => Document(hs, ds, filename)
   }
 
   lazy val header: Parser[Header] = include | cppInclude | namespace
 
   lazy val include = opt(comments) ~> "include" ~> stringLiteral ^^ { s =>
+    val includedPath = s.value
     val doc =
       if (skipIncludes) {
-        Document(Seq(), Seq())
+        Document(Seq(), Seq(), Some(includedPath))
       } else {
-        parseFile(s.value)
+        parseFile(includedPath)
       }
-    Include(s.value, doc)
+    Include(includedPath, doc)
   }
 
   // bogus dude.
@@ -417,20 +420,22 @@ class ThriftParser(
 
   lazy val defaultedAnnotations = opt(annotationGroup) ^^ { _ getOrElse Map.empty }
 
-  def parse[T](in: String, parser: Parser[T], file: Option[String] = None): T = try {
+  def parse[T](in: String, parser: Parser[T]): T = try {
     parseAll(parser, in) match {
       case Success(result, _) => result
       case x@Failure(msg, z) => throw new ParseException(x.toString)
       case x@Error(msg, _) => throw new ParseException(x.toString)
     }
   } catch {
-    case e: Throwable => throw file.map(FileParseException(_, e)).getOrElse(e)
+    case e: Throwable => throw filename.map(FileParseException(_, e)).getOrElse(e)
   }
 
   def parseFile(filename: String): Document = {
     val contents = importer(filename) getOrElse {
       throw new FileNotFoundException(filename)
     }
+
+    val newImporter = contents.importer
 
     // one thrift file can be included in another and referenced like this:
     // list<includedthriftfilenamehere.Request> requests
@@ -444,8 +449,9 @@ class ThriftParser(
       }
     }
 
-    val newParser = new ThriftParser(contents.importer, this.strict, this.defaultOptional, this.skipIncludes)
-    newParser.parse(contents.data, newParser.document, Some(filename))
+    val newParser = new ThriftParser(contents.importer, this.strict, this.defaultOptional,
+      this.skipIncludes, Some(filename))
+    newParser.parse(contents.data, newParser.document)
   }
 
   // helper functions

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/ASTSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/ASTSpec.scala
@@ -32,7 +32,7 @@ class ASTSpec extends Spec {
       val doc2 = Document(Seq(javaOatmealNs, Include("other", doc1)), Nil)
       val namespaceMap = Map(javaOatmealNs.id.fullName -> javaGranolaNs.id.fullName)
       doc2.mapNamespaces(namespaceMap) match {
-        case Document(Seq(javaGranolaNs, Include(_, included)), Nil) =>
+        case Document(Seq(javaGranolaNs, Include(_, included)), Nil, _) =>
           included must be(Document(Seq(javaGranolaNs), Nil))
       }
     }

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/MainSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/MainSpec.scala
@@ -47,9 +47,9 @@ struct Point {
     Main.main(args)
     val manifestString = Source.fromFile(fileMap).mkString
     val expected =
-      input.getPath + " -> " + buildPath(outDir.getPath, "MyTest", "Constants.scala") + "\n" +
-        input.getPath + " -> " + buildPath(outDir.getPath, "MyTest", "Direction.scala") + "\n" +
-        input.getPath + " -> " + buildPath(outDir.getPath, "MyTest", "Point.scala")+ "\n"
+      input.getPath + " -> " + buildPath(outDir.getPath, "MyTest", "inputConstants.scala") + "\n" +
+      input.getPath + " -> " + buildPath(outDir.getPath, "MyTest", "Direction.scala") + "\n" +
+      input.getPath + " -> " + buildPath(outDir.getPath, "MyTest", "Point.scala")+ "\n"
     manifestString must be(expected)
   }
 }

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/JavaGeneratorSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/JavaGeneratorSpec.scala
@@ -54,16 +54,16 @@ class JavaGeneratorSpec extends JMockSpec with EvalHelper {
     }
 
     "generate constants" in { _ =>
-      Constants.myWfhDay must be(WeekDay.THU)
-      Constants.myDaysOut must be(Utilities.makeList(WeekDay.THU, WeekDay.SAT, WeekDay.SUN))
-      Constants.name must be("Columbo")
-      Constants.someInt must be(1)
-      Constants.someDouble must be(3.0)
-      Constants.someList must be(Utilities.makeList("piggy"))
-      Constants.emptyList must be(Utilities.makeList())
-      Constants.someMap must be(Utilities.makeMap(Utilities.makeTuple("foo", "bar")))
-      Constants.someSimpleSet must be(Utilities.makeSet("foo", "bar"))
-      Constants.someSet must be(Utilities.makeSet(
+      constConstants.myWfhDay must be(WeekDay.THU)
+      constConstants.myDaysOut must be(Utilities.makeList(WeekDay.THU, WeekDay.SAT, WeekDay.SUN))
+      constConstants.name must be("Columbo")
+      constConstants.someInt must be(1)
+      constConstants.someDouble must be(3.0)
+      constConstants.someList must be(Utilities.makeList("piggy"))
+      constConstants.emptyList must be(Utilities.makeList())
+      constConstants.someMap must be(Utilities.makeMap(Utilities.makeTuple("foo", "bar")))
+      constConstants.someSimpleSet must be(Utilities.makeSet("foo", "bar"))
+      constConstants.someSet must be(Utilities.makeSet(
         Utilities.makeList("piggy"),
         Utilities.makeList("kitty")
       ))

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/NamingConvention.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/NamingConvention.scala
@@ -7,8 +7,8 @@ class NamingConventionSpec extends Spec {
 
     "follow naming conventions" in {
       import thrift.`def`.default._
-      Constants.`val` must be(10)
-      Constants.`try` must be(123)
+      naughtyConstants.`val` must be(10)
+      naughtyConstants.`try` must be(123)
 
       val naughty = Naughty("car", 100)
       naughty.`type` must be("car")
@@ -23,8 +23,8 @@ class NamingConventionSpec extends Spec {
   "Java Generator" should {
     "follow naming convention" in {
       import thrift.java_def._default_._ // package name "default" got rewritten in Java
-      Constants.`val` must be(10)
-      Constants._try_ must be(123)
+      naughtyConstants.`val` must be(10)
+      naughtyConstants._try_ must be(123)
 
       val naughty = new Naughty("car", 100)
       naughty.getType() must be("car")

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
@@ -217,16 +217,16 @@ class ScalaGeneratorSpec extends JMockSpec with EvalHelper {
     }
 
     "generate constants" in { _ =>
-      thrift.test.Constants.myWfhDay must be(WeekDay.Thu)
-      thrift.test.Constants.myDaysOut must be(List(WeekDay.Thu, WeekDay.Sat, WeekDay.SUN))
-      thrift.test.Constants.name must be("Columbo")
-      thrift.test.Constants.someInt must be(1)
-      thrift.test.Constants.someDouble must be(3.0)
-      thrift.test.Constants.someList must be(List("piggy"))
-      thrift.test.Constants.emptyList must be(List())
-      thrift.test.Constants.someMap must be(Map("foo" -> "bar"))
-      thrift.test.Constants.someSimpleSet must be(Set("foo", "bar"))
-      thrift.test.Constants.someSet must be(Set(
+      thrift.test.constConstants.myWfhDay must be(WeekDay.Thu)
+      thrift.test.constConstants.myDaysOut must be(List(WeekDay.Thu, WeekDay.Sat, WeekDay.SUN))
+      thrift.test.constConstants.name must be("Columbo")
+      thrift.test.constConstants.someInt must be(1)
+      thrift.test.constConstants.someDouble must be(3.0)
+      thrift.test.constConstants.someList must be(List("piggy"))
+      thrift.test.constConstants.emptyList must be(List())
+      thrift.test.constConstants.someMap must be(Map("foo" -> "bar"))
+      thrift.test.constConstants.someSimpleSet must be(Set("foo", "bar"))
+      thrift.test.constConstants.someSet must be(Set(
         List("piggy"),
         List("kitty")
       ))


### PR DESCRIPTION
This makes scrooge-generator run in parallel over multiple input files (via parallel collections).

This requires to change the output filenames and class names for constants. Scrooge currently produces a file Constants.scala for any file containing constants. To avoid the collision, we prepend the thrift filename to the output.

This still leaves the possibility of output file collision if the input is two thrift files with identical namespaces and basenames, but that would be a user error.

Benchmarking the multithreaded vs singlethreaded scrooge versions on a 24-core machine:

$ for i in $(seq 1000); do echo "service MyService$i { i32 getNumber(1: string someInput) }" > service$i.thrift; done

$ time java -jar ../scrooge-multithreaded.jar $files  -d out-multithreaded 2> /dev/null

real	0m7.474s
user	1m16.588s
sys	0m7.143s
$ time java -jar ../scrooge-singlethreaded.jar $files  -d out-singlethreaded 2> /dev/null

real	0m22.466s
user	0m26.486s
sys	0m1.690s
$ diff -r out-multithreaded out-singlethreaded
$
