### PR TITLE
Fix #151

### DIFF
--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -208,8 +208,14 @@ object ScroogeSBT extends Plugin {
     sourceGenerators <+= scroogeGen
   )
 
+  val packageThrift = mappings in (Compile, packageBin) ++= {
+    (scroogeThriftSources in Compile).value.map { file =>
+      file -> s"${name.value}/${file.name}"
+    }
+  }
+
   val newSettings =
     Seq(ivyConfigurations += thriftConfig) ++
     inConfig(Test)(genThriftSettings) ++
-    inConfig(Compile)(genThriftSettings)
+    inConfig(Compile)(genThriftSettings) :+ packageThrift
 }


### PR DESCRIPTION
[sbt-plugin] Add thrift files to published artifact

Problem

If someone has a project that compiles thrift but that also depends on a librairie that defines it's own thrift as well, this project needs to receive the thrift files of the dependency somehow. My understanding is that this functionality is part of the Scrooge maven plugin but not the sbt plugin currently.

Solution

The sbt-plugin now adds the thrift source files into the published jar file where both the maven plugin and the sbt plugin are already programmed to look for them.

Result

It is now possible for a project defining it's own thrift to depend on a "thrift" librairie using the Scrooge sbt-plugin to publish it's artifacts.
