### PR TITLE
Fix and unify boolean RHS parsing.	

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
@@ -143,7 +143,7 @@ class ThriftParser(
   // ride hand side (RHS)
 
   lazy val rhs: Parser[RHS] = {
-    numberLiteral | stringLiteral | boolLiteral | listOrMapRHS | mapRHS | idRHS |
+    numberLiteral | boolLiteral | stringLiteral | listOrMapRHS | mapRHS | idRHS |
       failure("constant expected")
   }
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/ThriftParser.scala
@@ -143,8 +143,13 @@ class ThriftParser(
   // ride hand side (RHS)
 
   lazy val rhs: Parser[RHS] = {
-    numberLiteral | stringLiteral | listOrMapRHS | mapRHS | idRHS |
+    numberLiteral | stringLiteral | boolLiteral | listOrMapRHS | mapRHS | idRHS |
       failure("constant expected")
+  }
+
+  lazy val boolLiteral: Parser[BoolLiteral] = ("true" | "True" | "false" | "False") ^^ { x =>
+    if (x.toLowerCase == "false") BoolLiteral(false)
+    else BoolLiteral(true)
   }
 
   lazy val intConstant = "[-+]?\\d+(?!\\.)".r ^^ {
@@ -223,19 +228,26 @@ class ThriftParser(
     literal => literal.value
   }
 
+  // Cast IntLiterals into booleans.
+  private[this] def convertRhs(fieldType: FieldType, rhs: RHS): RHS = {
+    fieldType match {
+      case TBool => rhs match {
+        case x: BoolLiteral => x
+        case IntLiteral(0) => BoolLiteral(false)
+        case IntLiteral(1) => BoolLiteral(true)
+        case _ => throw new TypeMismatchException(s"Can't assign $rhs to a bool")
+      }
+      case _ => rhs
+    }
+  }
+
   // fields
 
   lazy val field = (opt(comments) ~> opt(fieldId) ~ fieldReq) ~
     (fieldType ~ defaultedAnnotations ~ simpleID) ~
     opt("=" ~> rhs) ~ defaultedAnnotations <~ opt(listSeparator) ^^ {
       case (fid ~ req) ~ (ftype ~ typeAnnotations ~ sid) ~ value ~ fieldAnnotations => {
-        val transformedVal = ftype match {
-          case TBool => value map {
-            case IntLiteral(0) => BoolLiteral(false)
-            case _ => BoolLiteral(true)
-          }
-          case _ => value
-        }
+        val transformedVal = value.map(convertRhs(ftype, _))
 
         // if field is marked optional and a default is defined, ignore the optional part.
         val transformedReq = if (!defaultOptional && transformedVal.isDefined && req.isOptional) Requiredness.Default else req
@@ -287,7 +299,9 @@ class ThriftParser(
   lazy val definition = const | typedef | enum | senum | struct | union | exception | service
 
   lazy val const = opt(comments) ~ ("const" ~> fieldType) ~ simpleID ~ ("=" ~> rhs) ~ opt(listSeparator) ^^ {
-    case comment ~ ftype ~ sid ~ const ~ _ => ConstDefinition(sid, ftype, const, comment)
+    case comment ~ ftype ~ sid ~ const ~ _ => {
+      ConstDefinition(sid, ftype, convertRhs(ftype, const), comment)
+    }
   }
 
   lazy val typedef = (opt(comments) ~ "typedef") ~> fieldType ~ defaultedAnnotations ~ simpleID ^^ {

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
@@ -448,7 +448,8 @@ enum Foo
       }
 
       intercept[TypeMismatchException] {
-        parser.parse("service theService { i32 getValue(1: bool arg = SomethingElse) }", parser.service)
+        parser.parse("service theService { i32 getValue(1: bool arg = SomethingElse) }",
+          parser.service)
       }
 
       parser.parse("struct asdf { bool x = false }", parser.struct) must be (

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/frontend/ThriftParserSpec.scala
@@ -409,6 +409,64 @@ enum Foo
         }
       }
     }
+
+    "boolean default values" in {
+      var field = parser.parse("bool x = 0", parser.field)
+      field.default must be (Some(BoolLiteral(false)))
+
+      field = parser.parse("bool x = 1", parser.field)
+      field.default must be (Some(BoolLiteral(true)))
+
+      intercept[TypeMismatchException] {
+        parser.parse("bool x = 2", parser.field)
+      }
+
+      field = parser.parse("bool x = false", parser.field)
+      field.default must be (Some(BoolLiteral(false)))
+
+      field = parser.parse("bool x = true", parser.field)
+      field.default must be (Some(BoolLiteral(true)))
+
+      field = parser.parse("bool x = False", parser.field)
+      field.default must be (Some(BoolLiteral(false)))
+
+      field = parser.parse("bool x = True", parser.field)
+      field.default must be (Some(BoolLiteral(true)))
+
+      intercept[TypeMismatchException] {
+        parser.parse("bool x = WhatIsThis", parser.field)
+      }
+
+      parser.parse("const bool z = false", parser.const) must be (
+        ConstDefinition(SimpleID("z", None), TBool, BoolLiteral(false), None))
+
+      parser.parse("const bool z = True", parser.const) must be (
+        ConstDefinition(SimpleID("z", None), TBool, BoolLiteral(true), None))
+
+      intercept[TypeMismatchException] {
+        parser.parse("const bool z = IDontEven", parser.const)
+      }
+
+      intercept[TypeMismatchException] {
+        parser.parse("service theService { i32 getValue(1: bool arg = SomethingElse) }", parser.service)
+      }
+
+      parser.parse("struct asdf { bool x = false }", parser.struct) must be (
+        Struct(SimpleID("asdf", None), "asdf",
+          List(Field(-1, SimpleID("x", None), "x", TBool, Some(BoolLiteral(false)),
+            Requiredness.Default, Map(), Map())),
+          None,Map()))
+
+      parser.parse("struct asdf { bool x = 1 }", parser.struct) must be (
+        Struct(SimpleID("asdf", None), "asdf",
+          List(Field(-1, SimpleID("x", None), "x", TBool, Some(BoolLiteral(true)),
+            Requiredness.Default, Map(), Map())),
+          None,Map()))
+
+      intercept[TypeMismatchException] {
+        parser.parse("struct S { 1: bool B = 15 }", parser.struct)
+      }
+    }
   }
 
 


### PR DESCRIPTION
Problem

Scrooge is inconsistent in RHS handling for bool values, e.g.
```
const bool x = NotABool        # Throws an exception
const bool y = 1               # no exception, generates invalid scala like "val y: Boolean = 1"
struct S { bool x = NotABool } # no exception. Translated to true, valid scala generated.
struct S { bool x = false }    # Translated to true (!)
struct S { bool x = 1 }        # Translated to true (current workaround that doesn't work for consts)
```
Solution

Unify the handling of bool RHS values.

Result

Booleans get parsed as expected. Valid values are {true, True, false, False, 0, 1}; other values are not allowed.