### PR TITLE
[Fix #151] Add thrift files to published artifact in sbt-plugin

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,6 +7,7 @@ import com.typesafe.sbt.site.SphinxSupport.Sphinx
 import net.virtualvoid.sbt.graph.Plugin.graphSettings // For dependency-graph
 import sbtassembly.Plugin._
 import AssemblyKeys._
+import sbtbuildinfo.Plugin._
 
 object Scrooge extends Build {
   val libVersion = "3.17.0"
@@ -251,13 +252,17 @@ object Scrooge extends Build {
     base = file("scrooge-sbt-plugin"),
     settings = Project.defaultSettings ++
       sharedSettings ++
-      bintrayPublishSettings
+      bintrayPublishSettings ++
+      buildInfoSettings
   ).settings(
-    sbtPlugin := true,
-    publishMavenStyle := false,
-    repository in bintray := "sbt-plugins",
-    licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-    bintrayOrganization in bintray := Some("twittercsl")
+      sourceGenerators in Compile <+= buildInfo,
+      buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+      buildInfoPackage := "com.twitter",
+      sbtPlugin := true,
+      publishMavenStyle := false,
+      repository in bintray := "sbt-plugins",
+      licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+      bintrayOrganization in bintray := Some("twittercsl")
   ).dependsOn(scroogeGenerator)
 
   lazy val scroogeLinter = Project(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -111,10 +111,7 @@ object ScroogeSBT extends Plugin {
     scroogeThriftIncludeFolders <<= (scroogeThriftSourceFolder) { Seq(_) },
     scroogeThriftNamespaceMap := Map(),
     scroogeThriftDependencies := Seq(),
-    libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.9.0",
-      "com.twitter" %% "scrooge-core" % "3.17.1-SNAPSHOT"
-    ),
+    libraryDependencies += "com.twitter" %% "scrooge-core" % com.twitter.BuildInfo.version,
 
     // complete list of source files
     scroogeThriftSources <<= scroogeThriftSourceFolder map { (srcDir) => (srcDir ** "*.thrift").get },

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -39,6 +39,11 @@ object ScroogeSBT extends Plugin {
     "command line args to pass to scrooge"
   )
 
+  val scroogePublishThrift = SettingKey[Boolean](
+    "scrooge-publish-thrift",
+    "Whether or not to publish thrift files in the jar"
+  )
+
   val scroogeThriftDependencies = SettingKey[Seq[String]](
     "scrooge-thrift-dependencies",
     "artifacts to extract and compile thrift files from"
@@ -105,6 +110,7 @@ object ScroogeSBT extends Plugin {
    */
   val genThriftSettings: Seq[Setting[_]] = Seq(
     scroogeBuildOptions := Seq("--finagle"),
+    scroogePublishThrift := false,
     scroogeThriftSourceFolder <<= (sourceDirectory in Compile) { _ / "thrift" },
     scroogeThriftExternalSourceFolder <<= (target) { _ / "thrift_external" },
     scroogeThriftOutputFolder <<= (sourceManaged) { identity },
@@ -204,7 +210,7 @@ object ScroogeSBT extends Plugin {
   )
 
   val packageThrift = mappings in (Compile, packageBin) ++= {
-    (scroogeThriftSources in Compile).value.map { file =>
+    (if (scroogePublishThrift.value) (scroogeThriftSources in Compile).value else Nil).map { file =>
       file -> s"${name.value}/${file.name}"
     }
   }

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -111,7 +111,7 @@ object ScroogeSBT extends Plugin {
   val genThriftSettings: Seq[Setting[_]] = Seq(
     scroogeBuildOptions := Seq("--finagle"),
     scroogePublishThrift := false,
-    scroogeThriftSourceFolder <<= (sourceDirectory in Compile) { _ / "thrift" },
+    scroogeThriftSourceFolder <<= (sourceDirectory) { _ / "thrift" },
     scroogeThriftExternalSourceFolder <<= (target) { _ / "thrift_external" },
     scroogeThriftOutputFolder <<= (sourceManaged) { identity },
     scroogeThriftIncludeFolders <<= (scroogeThriftSourceFolder) { Seq(_) },
@@ -135,7 +135,7 @@ object ScroogeSBT extends Plugin {
     // returns Seq[File] - directories that include thrift files
     scroogeUnpackDeps <<= (
       streams,
-      configuration in Compile,
+      configuration,
       classpathTypes,
       update,
       scroogeThriftDependencies,
@@ -206,7 +206,7 @@ object ScroogeSBT extends Plugin {
       }
       (outputDir ** "*.scala").get.toSeq
     },
-    sourceGenerators in Compile <+= scroogeGen
+    sourceGenerators <+= scroogeGen
   )
 
   val packageThrift = mappings in (Compile, packageBin) ++= {
@@ -217,5 +217,6 @@ object ScroogeSBT extends Plugin {
 
   val newSettings =
     Seq(ivyConfigurations += thriftConfig) ++
-    genThriftSettings :+ packageThrift
+    inConfig(Test)(genThriftSettings) ++
+    inConfig(Compile)(genThriftSettings) :+ packageThrift
 }

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -208,8 +208,14 @@ object ScroogeSBT extends Plugin {
     sourceGenerators <+= scroogeGen
   )
 
+  val packageThrift = mappings in (Compile, packageBin) ++= {
+    (scroogeThriftSources in Compile).value.map { file =>
+      file -> s"${name.value}/${file.name}"
+    }
+  }
+
   val newSettings =
     Seq(ivyConfigurations += thriftConfig) ++
     inConfig(Test)(genThriftSettings) ++
-    inConfig(Compile)(genThriftSettings)
+    inConfig(Compile)(genThriftSettings) :+ packageThrift
 }


### PR DESCRIPTION
Problem

If someone has a project that compiles thrift but that also depends on a librairie that defines it's own thrift as well, this project needs to receive the thrift files of the dependency somehow. My understanding is that this functionality is part of the Scrooge maven plugin but not the sbt plugin currently.

Solution

On the publishing side, the sbt-plugin now adds the thrift source files into the published jar file where both the maven plugin and the sbt plugin are already programmed to look for them.

On the receiving side, the plugin does not consider the thrift files extracted from the jar as source but as includes so that it will not re-generate source files for these definitions as the class files for these classes exist already as per the dependency.

Result

It is now possible for a project defining it's own thrift to depend on a "thrift" librairie using the Scrooge sbt-plugin to publish it's artifacts.

Also, this change makes it easier to create fat jars for large downstream projects that depend on many thrift repos (like we have at Whitepages and I am sure at Twitter). Without this change, you end up with multiple versions of the same classes that were generated by many of the dependencies.