### PR TITLE
[sbt-plugin] Fix overriding default settings

### DIFF
--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -106,7 +106,7 @@ object ScroogeSBT extends Plugin {
    */
   val genThriftSettings: Seq[Setting[_]] = Seq(
     scroogeBuildOptions := Seq("--finagle"),
-    scroogeThriftSourceFolder <<= (sourceDirectory) { _ / "thrift" },
+    scroogeThriftSourceFolder <<= (sourceDirectory in Compile) { _ / "thrift" },
     scroogeThriftExternalSourceFolder <<= (target) { _ / "thrift_external" },
     scroogeThriftOutputFolder <<= (sourceManaged) { identity },
     scroogeThriftIncludeFolders <<= (scroogeThriftSourceFolder) { Seq(_) },
@@ -134,7 +134,7 @@ object ScroogeSBT extends Plugin {
     // returns Seq[File] - directories that include thrift files
     scroogeUnpackDeps <<= (
       streams,
-      configuration,
+      configuration in Compile,
       classpathTypes,
       update,
       scroogeThriftDependencies,
@@ -205,11 +205,10 @@ object ScroogeSBT extends Plugin {
       }
       (outputDir ** "*.scala").get.toSeq
     },
-    sourceGenerators <+= scroogeGen
+    sourceGenerators in Compile <+= scroogeGen
   )
 
   val newSettings =
     Seq(ivyConfigurations += thriftConfig) ++
-    inConfig(Test)(genThriftSettings) ++
-    inConfig(Compile)(genThriftSettings)
+    genThriftSettings
 }


### PR DESCRIPTION
I'll be the first to admit that I am by no stretch of the mind an expert at sbt scopes, however I do think there is a problem and that this is a fix for it.

**Problem:**

After adding the Scrooge sbt-plugin with something like this:

`addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.17.1-SNAPSHOT")`

And having a build.sbt that looks something like this:

    ...

    com.twitter.scrooge.ScroogeSBT.newSettings

    scroogeBuildOptions := Seq()

    scroogeThriftSourceFolder <<= (baseDirectory) { _ / "thrift" / "wp-data" }

 None of these two settings overrides will be respected. The plugin will generate thrift with the defaults, that is Finagle bindings and look for thrift files in /scr/main/thrift

 **Solution:**

 Change scopes for default settings definitions so that one can easily change the defaults.

 **Result**

 Settings overrides are considered by the plugin.