### PR TITLE
Documentation update on how to get scrooge-sbt-plugin.

### DIFF
--- a/doc/src/sphinx/SBTPlugin.rst
+++ b/doc/src/sphinx/SBTPlugin.rst
@@ -1,6 +1,8 @@
 SBT Plugin
 ==========
 
+The scrooge-sbt-plugin is not published to Maven Central but published to `Bintray <https://bintray.com/twittercsl/sbt-plugins/scrooge-sbt-plugin/view>`_
+
 Add a line like this to your `project/plugins.sbt` file:
 
 ::

--- a/doc/src/sphinx/index.rst
+++ b/doc/src/sphinx/index.rst
@@ -63,6 +63,8 @@ To build scrooge, use sbt:
 
     $ ./sbt +publish-local
 
+This will currently not build and publish the scrooge-sbt-plugin.
+
 User's guide
 ------------
 

--- a/doc/src/sphinx/index.rst
+++ b/doc/src/sphinx/index.rst
@@ -61,7 +61,7 @@ To build scrooge, use sbt:
 
 ::
 
-    $ ./sbt +publish-local
+    $ ./sbt +publishLocal
 
 This will currently not build and publish the scrooge-sbt-plugin.
 You can still build the scrooge-sbt-plugin separately by executing:
@@ -69,7 +69,7 @@ You can still build the scrooge-sbt-plugin separately by executing:
 ::
     $ ./sbt
     > project scrooge-sbt-plugin
-    > +publish-local
+    > +publishLocal
 
 User's guide
 ------------

--- a/doc/src/sphinx/index.rst
+++ b/doc/src/sphinx/index.rst
@@ -64,6 +64,12 @@ To build scrooge, use sbt:
     $ ./sbt +publish-local
 
 This will currently not build and publish the scrooge-sbt-plugin.
+You can still build the scrooge-sbt-plugin separately by executing:
+
+::
+    $ ./sbt
+    > project scrooge-sbt-plugin
+    > +publish-local
 
 User's guide
 ------------

--- a/doc/src/sphinx/index.rst
+++ b/doc/src/sphinx/index.rst
@@ -61,7 +61,7 @@ To build scrooge, use sbt:
 
 ::
 
-    $ ./sbt +publishLocal
+    $ ./sbt publishLocal
 
 This will currently not build and publish the scrooge-sbt-plugin.
 You can still build the scrooge-sbt-plugin separately by executing:
@@ -69,7 +69,7 @@ You can still build the scrooge-sbt-plugin separately by executing:
 ::
     $ ./sbt
     > project scrooge-sbt-plugin
-    > +publishLocal
+    > publishLocal
 
 User's guide
 ------------


### PR DESCRIPTION
The sbt plugin was not added to the aggregates. This was confusing
as after publish it was not available.