### PR TITLE
Update docs with new versions and repository for SBT plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ Maven users need to add the following to the pom.xml file:
 
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>scrooge-core_2.9.2</artifactId>
-      <version>3.3.2</version>
+      <artifactId>scrooge-core_2.10</artifactId>
+      <version>3.18.0</version>
     </dependency>
 
 SBT users need this:
 
-    val scroogeCore = "com.twitter" %% "scrooge-core" % "3.3.2"
+    val scroogeCore = "com.twitter" %% "scrooge-core" % "3.18.0"
 
 ## Building the develop branch locally
 
 You will need the develop branches of util, ostrich, and finagle.
-Then `./sbt publish-local` for each of them.
+Then `./sbt publishLocal` for each of them.
 
 ## Full Documentation
 

--- a/doc/src/sphinx/SBTPlugin.rst
+++ b/doc/src/sphinx/SBTPlugin.rst
@@ -5,6 +5,8 @@ Add a line like this to your `project/plugins.sbt` file:
 
 ::
 
+    resolvers += "Twitter's Repository" at "http://maven.twttr.com/"
+
     addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.18.0")
 
 In your `build.sbt` file:
@@ -12,9 +14,9 @@ In your `build.sbt` file:
 ::
 
     libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.8.0",
+      "org.apache.thrift" % "libthrift" % "0.5.0-1",
       "com.twitter" %% "scrooge-core" % "3.18.0",
-      "com.twitter" %% "finagle-thrift" % "6.24.0"
+      "com.twitter" %% "finagle-thrift" % "6.25.0"
     )
 
 or, in your `project/Build.scala` file:
@@ -27,9 +29,9 @@ or, in your `project/Build.scala` file:
       settings = Project.defaultSettings
     ).settings(
       libraryDependencies ++= Seq(
-        "org.apache.thrift" % "libthrift" % "0.8.0",
+        "org.apache.thrift" % "libthrift" % "0.5.0-1",
         "com.twitter" %% "scrooge-core" % "3.18.0",
-        "com.twitter" %% "finagle-thrift" % "6.24.0"
+        "com.twitter" %% "finagle-thrift" % "6.25.0"
       )
     )
 

--- a/doc/src/sphinx/index.rst
+++ b/doc/src/sphinx/index.rst
@@ -44,15 +44,15 @@ Maven users need to add the following to the pom.xml file:
 
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>scrooge-core_2.9.2</artifactId>
-      <version>3.3.2</version>
+      <artifactId>scrooge-core_2.10</artifactId>
+      <version>3.18.0</version>
     </dependency>
 
 SBT users need this:
 
 ::
 
-    val scroogeCore = "com.twitter" %% "scrooge-core" % "3.3.2"
+    val scroogeCore = "com.twitter" %% "scrooge-core" % "3.18.0"
 
 Building Scrooge
 ----------------
@@ -61,7 +61,7 @@ To build scrooge, use sbt:
 
 ::
 
-    $ ./sbt +publish-local
+    $ ./sbt +publishLocal
 
 User's guide
 ------------


### PR DESCRIPTION
Problem

Because we've reverted libthrift to 0.5.0-1, it's now necessary to add the
Twitter Maven repository to the SBT meta-meta-build for projects that use the
Scrooge SBT plugin. The docs don't make this clear.

Solution

Add a line to the example in the docs. I've also updated some other versions
while I'm here.