### PR TITLE
Changes `scroogeGen` to only return the files it generated.

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -41,7 +41,7 @@ class Compiler {
   var defaultNamespace: String = "thrift"
   var scalaWarnOnJavaNSFallback: Boolean = false
 
-  def run() {
+  def run(): List[String] = {
     // if --gen-file-map is specified, prepare the map file.
     fileMapWriter = fileMapPath.map { path =>
       val file = new File(path)
@@ -61,7 +61,7 @@ class Compiler {
     val documentCache = new TrieMap[String, Document]
 
     // compile
-    for (inputFile <- thriftFiles) {
+    val dstFiles = thriftFiles.flatMap { inputFile =>
       val parser = new ThriftParser(importer, strict, defaultOptional = isJava, skipIncludes = false, documentCache)
       val doc0 = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
 
@@ -93,9 +93,13 @@ class Compiler {
           w.write(inputFile + " -> " + path + "\n")
         }
       }
+
+      generatedFiles
     }
 
     // flush and close the map file
     fileMapWriter.foreach { _.close() }
+
+    dstFiles.toList
   }
 }


### PR DESCRIPTION
Previously `scroogeGen` would return all files under `src_managed` this
breaks the Scala 2.11 compiler if another generated also generated files
and returned them.

This uses a mutable ListBuffer in a setting to cache the list of files
that have been generated.

This closes #188.