### PR TITLE
Upgrade Scrooge to support Scala 2.11

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -64,7 +64,7 @@ object Scrooge extends Build {
     version := libVersion,
     organization := "com.twitter",
     // 2.11-ification needs more work with mustache
-    crossScalaVersions := Seq("2.10.5" /*, "2.11.6"*/),
+    crossScalaVersions := Seq("2.10.5" , "2.11.7"),
     scalaVersion := "2.10.5",
 
     resolvers ++= Seq(
@@ -93,7 +93,7 @@ object Scrooge extends Build {
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.4" % "test",
       "org.scalacheck" %% "scalacheck" % "1.12.2" % "test",
-      "junit" % "junit" % "4.10" % "test" exclude("org.mockito", "mockito-all")
+      "junit" % "junit" % "4.12" % "test"
     ),
     resolvers += "twitter-repo" at "http://maven.twttr.com",
 
@@ -183,6 +183,7 @@ object Scrooge extends Build {
       "org.apache.thrift" % "libthrift" % "0.5.0-1",
       "com.github.scopt" %% "scopt" % "3.2.0",
       "com.novocode" % "junit-interface" % "0.8" % "test->default" exclude("org.mockito", "mockito-all"),
+      "com.github.spullara.mustache.java" % "compiler" % "0.8.17",
       "org.codehaus.plexus" % "plexus-utils" % "1.5.4",
       "org.slf4j" % "slf4j-log4j12" % "1.6.6" % "test", // used in thrift transports
       "com.google.code.findbugs" % "jsr305" % "1.3.9",
@@ -190,19 +191,6 @@ object Scrooge extends Build {
       finagle("core") exclude("org.mockito", "mockito-all"),
       finagle("thrift") % "test"
     ),
-    libraryDependencies <++= scalaVersion({
-      case version if version.startsWith("2.10.") =>
-        Seq(
-          "com.github.spullara.mustache.java" % "scala-extensions-2.10" % "0.8.17",
-          "com.github.spullara.mustache.java" % "compiler" % "0.8.17"
-        )
-      case version if version.startsWith("2.11.") =>
-        Seq(
-          "com.github.spullara.mustache.java" % "scala-extensions-2.11" % "0.9.0",
-          "com.github.spullara.mustache.java" % "compiler" % "0.9.0"
-        )
-
-    }),
     test in assembly := {},  // Skip tests when running assembly.
     mainClass in assembly := Some("com.twitter.scrooge.Main")
   ).dependsOn(scroogeRuntime % "test")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -63,7 +63,6 @@ object Scrooge extends Build {
   val sharedSettings = Seq(
     version := libVersion,
     organization := "com.twitter",
-    // 2.11-ification needs more work with mustache
     crossScalaVersions := Seq("2.10.5" , "2.11.7"),
     scalaVersion := "2.10.5",
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
@@ -1,7 +1,7 @@
 package com.twitter.scrooge.java_generator
 
 import com.github.mustachejava.{DefaultMustacheFactory, Mustache}
-import com.twitter.mustache.ScalaObjectHandler
+import com.twitter.scrooge.mustache.ScalaObjectHandler
 import com.twitter.scrooge.ast.{EnumType, ListType, MapType, ReferenceType, SetType, StructType, _}
 import com.twitter.scrooge.backend.{GeneratorFactory, ServiceOption, ThriftGenerator}
 import com.twitter.scrooge.frontend.{ResolvedDocument, ScroogeInternalException}

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/mustache/ScalaObjectHandler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/mustache/ScalaObjectHandler.scala
@@ -1,0 +1,72 @@
+package com.twitter.scrooge.mustache
+
+import collection.JavaConversions._
+import com.github.mustachejava.Iteration
+import com.github.mustachejava.reflect.ReflectionObjectHandler
+import java.io.Writer
+import java.lang.reflect.{Field, Method}
+import runtime.BoxedUnit
+import scala.reflect.ClassTag
+
+/**
+ * This class is borrowed from Mustache.java in scala-extensions. Its package
+ * has been renamed from com.twitter.mustache to com.twitter.scrooge.mustache,
+ * so it won't collide if a user also has included the scala-extensions jar in
+ * their classpath.
+ */
+private[scrooge] class ScalaObjectHandler extends ReflectionObjectHandler {
+
+  // Allow any method or field
+  override def checkMethod(member: Method) {}
+
+  override def checkField(member: Field) {}
+
+  override def coerce(value: AnyRef) = {
+    value match {
+      case m: collection.Map[_, _] => mapAsJavaMap(m)
+      case u: BoxedUnit => null
+      case Some(some: AnyRef) => coerce(some)
+      case None => null
+      case _ => value
+    }
+  }
+
+  override def iterate(iteration: Iteration, writer: Writer, value: AnyRef, scopes: Array[AnyRef]) = {
+    value match {
+      case TraversableAnyRef(t) => {
+        var newWriter = writer
+        t foreach {
+          next =>
+            newWriter = iteration.next(newWriter, coerce(next), scopes)
+        }
+        newWriter
+      }
+      case n: Number => if (n.intValue() == 0) writer else iteration.next(writer, coerce(value), scopes)
+      case _ => super.iterate(iteration, writer, value, scopes)
+    }
+  }
+
+  override def falsey(iteration: Iteration, writer: Writer, value: AnyRef, scopes: Array[AnyRef]) = {
+    value match {
+      case TraversableAnyRef(t) => {
+        if (t.isEmpty) {
+          iteration.next(writer, value, scopes)
+        } else {
+          writer
+        }
+      }
+      case n: Number => if (n.intValue() == 0) iteration.next(writer, coerce(value), scopes) else writer
+      case _ => super.falsey(iteration, writer, value, scopes)
+    }
+  }
+
+  val TraversableAnyRef = new Def[Traversable[AnyRef]]
+  class Def[C: ClassTag] {
+    def unapply[X: ClassTag](x: X): Option[C] = {
+      x match {
+        case c: C => Some(c)
+        case _ => None
+      }
+    }
+  }
+}

--- a/scrooge-generator/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
+++ b/scrooge-generator/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
@@ -3,7 +3,7 @@ package com.twitter.scrooge.java_generator
 import com.github.mustachejava.{DefaultMustacheFactory, Mustache}
 import com.google.common.base.Charsets
 import com.google.common.io.CharStreams
-import com.twitter.mustache.ScalaObjectHandler
+import com.twitter.scrooge.mustache.ScalaObjectHandler
 import com.twitter.scrooge.ast._
 import com.twitter.scrooge.frontend.{ResolvedDocument, TypeResolver, _}
 import com.twitter.scrooge.java_generator.test.ApacheCompatibilityHelpers


### PR DESCRIPTION
Problem:
Scrooge only compiles with Scala 2.10, but many
projects need Scrooge on 2.11.

Solution:
Make small changes to the code, so that it works
with Scala 2.11.

- Use stable versions of Finagle (since this is the OSS version)
- Move scrooge version to version.sbt
- Inline Mustache.java's Scala extension
- Bump junit