### PR TITLE
scrooge: Add explicit type arguments when generating Java code

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
@@ -76,11 +76,15 @@ class JavaGenerator(
     fieldType: Option[FieldType] = None
   ): CodeFragment = {
     val listElemType = fieldType.map(_.asInstanceOf[ListType].eltType)
+    val typeArgument = listElemType match {
+      case Some(elemType) => "<" + genType(elemType).toData + ">"
+      case _ => ""
+    }
     val code =
       list.elems.map { e =>
         genConstant(e, listElemType).toData
       }.mkString(", ")
-    v(s"Utilities.makeList($code)")
+    v(s"Utilities.${typeArgument}makeList($code)")
   }
 
   def genSet(
@@ -93,11 +97,16 @@ class JavaGenerator(
     }
 
     val setElemType = fieldType.map(_.asInstanceOf[SetType].eltType)
+    val typeArgument = setElemType match {
+      case Some(elemType) => "<" + genType(elemType).toData + ">"
+      case _ => ""
+    }
+
     val code = set.elems.map { e =>
       genConstant(e, setElemType).toData
     }.mkString(", ")
 
-    v(s"Utilities.$makeSetMethod($code)")
+    v(s"Utilities.$typeArgument$makeSetMethod($code)")
   }
 
   def genMap(
@@ -105,13 +114,19 @@ class JavaGenerator(
     fieldType: Option[FieldType] = None
   ): CodeFragment = {
     val mapType = fieldType.map(_.asInstanceOf[MapType])
+    val typeArguments = mapType match {
+      case Some(MapType(keyType, valueType, _)) =>
+        s"<${genType(keyType).toData},${genType(valueType).toData}>"
+      case _ => ""
+    }
+
     val code = map.elems.map { case (k, v) =>
       val key = genConstant(k, mapType.map(_.keyType)).toData
       val value = genConstant(v, mapType.map(_.valueType)).toData
-      s"Utilities.makeTuple($key, $value)"
+      s"Utilities.${typeArguments}makeTuple($key, $value)"
     }.mkString(", ")
 
-    v(s"Utilities.makeMap($code)")
+    v(s"Utilities.${typeArguments}makeMap($code)")
   }
 
   def genEnum(enum: EnumRHS, fieldType: Option[FieldType] = None): CodeFragment = {

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
@@ -137,9 +137,15 @@ class JavaGenerator(
     genID(enum.value.sid.toUpperCase.addScope(getTypeId.toTitleCase))
   }
 
-  // TODO
-  def genStruct(struct: StructRHS): CodeFragment = ???
+  def genStruct(struct: StructRHS): CodeFragment = {
+    val code = "new " + struct.sid.name + ".Builder()" + 
+        struct.elems.map { case (field, rhs) => 
+          "." + field.sid.name + "(" + genConstant(rhs) + ")"
+         }.mkString("") +".build()"
+     v(code)
+  }
 
+  // TODO
   def genUnion(union: UnionRHS): CodeFragment = ???
 
   override def genDefaultValue(fieldType: FieldType): CodeFragment = {

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
@@ -140,7 +140,7 @@ class JavaGenerator(
   def genStruct(struct: StructRHS): CodeFragment = {
     val code = "new " + struct.sid.name + ".Builder()" + 
         struct.elems.map { case (field, rhs) => 
-          "." + field.sid.name + "(" + genConstant(rhs) + ")"
+          "." + field.sid.name + "(" + genConstant(rhs, Some(field.fieldType)) + ")"
          }.mkString("") +".build()"
      v(code)
   }

--- a/scrooge-generator/src/test/thrift/integration/apache_standard_tests.thrift
+++ b/scrooge-generator/src/test/thrift/integration/apache_standard_tests.thrift
@@ -130,6 +130,16 @@ struct OneField {
   1: EmptyStruct field
 }
 
+struct StructWithMap {
+  1: map<string, i32> data,
+  2: list<i32> emptylist
+}
+
+const StructWithMap constWithRHS = {
+  "data": { "a": 1, "b": 2 },
+  "emptylist": []
+}
+
 service ThriftTest
 {
   /**


### PR DESCRIPTION
Problem

The Java compiler cannot infer type arguments (like Scala does) when
we inline function calls. Therefore, we need to call Utilities.makeXXX
with explicit types, e.g. Utilities.<String,String>makeMap().
The problem will only come up when we generate RHS structs
with builders (PR #200).

Example:

```
struct Foo {
  1: list<i32> bars;
}

new Foo.Builder().bars(Utilities.makeList()).build();
```

will fail, while

```
new Foo.Builder().bars(Utilities.<Integer>makeList()).build();
```

will compile.

Solution

Add type arguments to code generation for Utilities.