### PR TITLE
Allow eponymously named services.

### DIFF
--- a/scrooge-generator/src/main/resources/javagen/finagleService.java
+++ b/scrooge-generator/src/main/resources/javagen/finagleService.java
@@ -1,6 +1,5 @@
 package {{package}};
 
-import com.twitter.finagle.Service;
 import com.twitter.finagle.SourcedException;
 import com.twitter.finagle.stats.Counter;
 import com.twitter.finagle.stats.NullStatsReceiver;

--- a/scrooge-generator/src/main/resources/javagen/service.java
+++ b/scrooge-generator/src/main/resources/javagen/service.java
@@ -16,7 +16,6 @@ import java.util.HashSet;
 import org.apache.thrift.protocol.*;
 import org.apache.thrift.TApplicationException;
 {{#withFinagle}}
-import com.twitter.finagle.Service;
 import com.twitter.finagle.SourcedException;
 import com.twitter.finagle.stats.Counter;
 import com.twitter.finagle.stats.NullStatsReceiver;

--- a/scrooge-generator/src/main/resources/scalagen/finagleClient.scala
+++ b/scrooge-generator/src/main/resources/scalagen/finagleClient.scala
@@ -1,6 +1,6 @@
 package {{package}}
 
-import com.twitter.finagle.{SourcedException, Service}
+import com.twitter.finagle.SourcedException
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
 import com.twitter.finagle.thrift.{Protocols, ThriftClientRequest}
 import com.twitter.scrooge.{ThriftStruct, ThriftStructCodec}
@@ -17,7 +17,7 @@ import scala.language.higherKinds
 {{docstring}}
 @javax.annotation.Generated(value = Array("com.twitter.scrooge.Compiler"))
 class {{ServiceName}}$FinagleClient(
-    {{#hasParent}}override {{/hasParent}}val service: Service[ThriftClientRequest, Array[Byte]],
+    {{#hasParent}}override {{/hasParent}}val service: com.twitter.finagle.Service[ThriftClientRequest, Array[Byte]],
     {{#hasParent}}override {{/hasParent}}val protocolFactory: TProtocolFactory = Protocols.binaryFactory(),
     {{#hasParent}}override {{/hasParent}}val serviceName: String = "{{ServiceName}}",
     stats: StatsReceiver = NullStatsReceiver

--- a/scrooge-generator/src/main/resources/scalagen/finagleService.scala
+++ b/scrooge-generator/src/main/resources/scalagen/finagleService.scala
@@ -1,6 +1,6 @@
 package {{package}}
 
-import com.twitter.finagle.{Service, Thrift}
+import com.twitter.finagle.Thrift
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
 import com.twitter.scrooge.{ThriftStruct, TReusableMemoryTransport}
 import com.twitter.util.Future

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/JavaGenerator.scala
@@ -224,7 +224,7 @@ class JavaGenerator(
     v(code)
   }
 
-  def genBaseFinagleService = v("Service<byte[], byte[]>")
+  def genBaseFinagleService = v("com.twitter.finagle.Service<byte[], byte[]>")
 
   def getParentFinagleService(p: ServiceParent): CodeFragment =
     genID(SimpleID("FinagledService").addScope(getServiceParentID(p)))

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
@@ -222,7 +222,7 @@ class ScalaGenerator(
     v(code)
   }
 
-  def genBaseFinagleService: CodeFragment = v("Service[Array[Byte], Array[Byte]]")
+  def genBaseFinagleService: CodeFragment = v("com.twitter.finagle.Service[Array[Byte], Array[Byte]]")
 
   def getParentFinagleService(p: ServiceParent): CodeFragment =
     genID(Identifier(getServiceParentID(p).fullName + "$FinagleService"))

--- a/scrooge-generator/src/test/thrift/standalone/test.thrift
+++ b/scrooge-generator/src/test/thrift/standalone/test.thrift
@@ -545,3 +545,8 @@ service Defaults {
     6: optional bool arg6 = true
   )
 }
+
+/* Eponymous Service caused import clash as of 4.0.0 */
+service Service {
+  oneway void test()
+}


### PR DESCRIPTION
Fixes the import clash with the generated code a thrift service named `Service` and the import of  `com.twitter.finagle.Service`. 

(Conceivably, the same problem could occur if someone created a thrift service named `TReusableMemoryTransport` or any of the other imported names in `finagleService.scala` .. but luckily I don't work somewhere where people would be so awkward :) )
