### PR TITLE
Add twitter resolver to plugins.sbt

### DIFF
--- a/SBTPlugin.html
+++ b/SBTPlugin.html
@@ -60,6 +60,9 @@
 <h1>SBT Plugin<a class="headerlink" href="#sbt-plugin" title="Permalink to this headline">¶</a></h1>
 <p>Add a line like this to your <cite>project/plugins.sbt</cite> file:</p>
 <div class="highlight-text"><div class="highlight"><pre>addSbtPlugin(&quot;com.twitter&quot; %% &quot;scrooge-sbt-plugin&quot; % &quot;3.18.1&quot;)
+
+resolvers += &quot;twitter-repo&quot; at &quot;https://maven.twttr.com&quot;
+
 </pre></div>
 </div>
 <p>In your <cite>build.sbt</cite> file:</p>


### PR DESCRIPTION
You need the twitter resolver in order to get the latest dependencies.

Without this line, adding the latest version of the plugin fails with the error:

```
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: org.apache.thrift#libthrift;0.5.0-1: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
```