### PR TITLE
Fix name conflict in ScroogeSBT

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,18 @@ SBT users need this:
 
 ## Building the develop branch locally
 
-You will need the develop branches of util, ostrich, and finagle.
-Then `./sbt publish-local` for each of them.
+You will need the develop branches of [util](https://github.com/twitter/util),
+[ostrich](https://github.com/twitter/ostrich),
+and [finagle](https://github.com/twitter/finagle).
+Finagle depends on `scrooge-core`, so the order in which you build dependencies
+should be:
+
+* in util: `./sbt publish-local`
+* in ostrich: `./sbt publish-local`
+* in scrooge: `./sbt 'project scrooge-core' publish-local`
+* in finagle: `/.sbt publish-local`
+
+Then you can build the entire scrooge package.
 
 ## Full Documentation
 

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -10,7 +10,7 @@ object ScroogeSBT extends AutoPlugin {
   private[this] def generatedExtensionPattern(language: String): String =
     if (language.endsWith("java")) "*.java" else "*.scala"
 
-  def compileThrift(
+  private[this] def compile(
     log: Logger,
     outputDir: File,
     thriftFiles: Set[File],
@@ -238,7 +238,7 @@ object ScroogeSBT extends AutoPlugin {
       // for some reason, sbt sometimes calls us multiple times, often with no source files.
       if (isDirty && sources.nonEmpty) {
         out.log.info("Generating scrooge thrift for %s ...".format(sources.mkString(", ")))
-        compileThrift(out.log, outputDir, sources.toSet, inc.toSet, ns, language, opts.toSet)
+        compile(out.log, outputDir, sources.toSet, inc.toSet, ns, language, opts.toSet)
       }
       (outputDir ** generatedExtensionPattern(language)).get.toSeq
     },

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -10,7 +10,7 @@ object ScroogeSBT extends AutoPlugin {
   private[this] def generatedExtensionPattern(language: String): String =
     if (language.endsWith("java")) "*.java" else "*.scala"
 
-  def compile(
+  def compileThrift(
     log: Logger,
     outputDir: File,
     thriftFiles: Set[File],
@@ -238,7 +238,7 @@ object ScroogeSBT extends AutoPlugin {
       // for some reason, sbt sometimes calls us multiple times, often with no source files.
       if (isDirty && sources.nonEmpty) {
         out.log.info("Generating scrooge thrift for %s ...".format(sources.mkString(", ")))
-        compile(out.log, outputDir, sources.toSet, inc.toSet, ns, language, opts.toSet)
+        compileThrift(out.log, outputDir, sources.toSet, inc.toSet, ns, language, opts.toSet)
       }
       (outputDir ** generatedExtensionPattern(language)).get.toSeq
     },


### PR DESCRIPTION
@mosesn fixes #209 

the `compile` method is public however, so it's unclear if anyone in the wild references this directly in their build.sbt. if so, this would be considered a breaking change. 

an alternative solution would be to just make the method private. i don't know enough about `scrooge` yet to tell whether this is preferred, please let me know.

note that i updated the README to reflect the extra step required for me to build this package. also note that in order to get everything to compile, i had to explicitly build against scala 2.10.6. i'm not sure if this is expected.

