### PR TITLE
Add per function name stats tracking for generated scala service code.

### DIFF
--- a/scrooge-generator/src/main/resources/scalagen/finagleService.scala
+++ b/scrooge-generator/src/main/resources/scalagen/finagleService.scala
@@ -3,7 +3,7 @@ package {{package}}
 import com.twitter.finagle.Thrift
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
 import com.twitter.scrooge.{ThriftStruct, TReusableMemoryTransport}
-import com.twitter.util.Future
+import com.twitter.util.{Future, Return, Throw, Throwables}
 import java.nio.ByteBuffer
 import java.util.Arrays
 import org.apache.thrift.protocol._
@@ -21,15 +21,22 @@ class {{ServiceName}}$FinagleService(
   iface: {{ServiceName}}[Future],
   protocolFactory: TProtocolFactory,
   stats: StatsReceiver,
-  maxThriftBufferSize: Int
+  maxThriftBufferSize: Int,
+  serviceName: String
 ) extends {{finagleServiceParent}}{{#hasParent}}(iface, protocolFactory, stats, maxThriftBufferSize){{/hasParent}} {
   import {{ServiceName}}._
 
   def this(
     iface: {{ServiceName}}[Future],
+    protocolFactory: TProtocolFactory,
+    stats: StatsReceiver,
+    maxThriftBufferSize: Int
+  ) = this(iface, protocolFactory, stats, maxThriftBufferSize, "{{ServiceName}}")
+
+  def this(
+    iface: {{ServiceName}}[Future],
     protocolFactory: TProtocolFactory
   ) = this(iface, protocolFactory, NullStatsReceiver, Thrift.maxThriftBufferSize)
-
 {{^hasParent}}
 
   private[this] val tlReusableBuffer = new ThreadLocal[TReusableMemoryTransport] {
@@ -119,6 +126,7 @@ class {{ServiceName}}$FinagleService(
   // ---- end boilerplate.
 
 {{/hasParent}}
+  private[this] val scopedStats = if (serviceName != "") stats.scope(serviceName) else stats
 {{#functions}}
   {{>function}}
 {{/function}}

--- a/scrooge-generator/src/main/resources/scalagen/finagleServiceFunction.scala
+++ b/scrooge-generator/src/main/resources/scalagen/finagleServiceFunction.scala
@@ -1,20 +1,33 @@
+private[this] object {{__stats_name}} {
+  val RequestsCounter = scopedStats.scope("{{serviceFuncNameForWire}}").counter("requests")
+  val SuccessCounter = scopedStats.scope("{{serviceFuncNameForWire}}").counter("success")
+  val FailuresCounter = scopedStats.scope("{{serviceFuncNameForWire}}").counter("failures")
+  val FailuresScope = scopedStats.scope("{{serviceFuncNameForWire}}").scope("failures")
+}
 addFunction("{{serviceFuncNameForWire}}", { (iprot: TProtocol, seqid: Int) =>
   try {
+    {{__stats_name}}.RequestsCounter.incr()
     val args = {{funcObjectName}}.Args.decode(iprot)
     iprot.readMessageEnd()
     (try {
       iface.{{serviceFuncNameForCompile}}({{argNames}})
     } catch {
       case e: Exception => Future.exception(e)
-    }) flatMap { value: {{typeName}} =>
+    }).flatMap { value: {{typeName}} =>
       reply("{{serviceFuncNameForWire}}", seqid, {{funcObjectName}}.Result({{resultNamedArg}}))
-    } rescue {
+    }.rescue {
 {{#exceptions}}
       case e: {{exceptionType}} => {
         reply("{{serviceFuncNameForWire}}", seqid, {{funcObjectName}}.Result({{fieldName}} = Some(e)))
       }
 {{/exceptions}}
       case e => Future.exception(e)
+    }.respond {
+      case Return(_) =>
+        {{__stats_name}}.SuccessCounter.incr()
+      case Throw(ex) =>
+        {{__stats_name}}.FailuresCounter.incr()
+        {{__stats_name}}.FailuresScope.counter(Throwables.mkString(ex): _*).incr()
     }
   } catch {
     case e: TProtocolException => {

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ServiceTemplate.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ServiceTemplate.scala
@@ -17,9 +17,10 @@ package com.twitter.scrooge.backend
  */
 
 import com.twitter.scrooge.ast._
-import com.twitter.scrooge.frontend.{ResolvedService, TypeResolver, ResolvedDocument}
+import com.twitter.scrooge.frontend.ResolvedService
 import com.twitter.scrooge.mustache.Dictionary
 import com.twitter.scrooge.mustache.Dictionary._
+
 import scala.collection.mutable
 
 trait ServiceTemplate { self: TemplateGenerator =>
@@ -155,6 +156,7 @@ trait ServiceTemplate { self: TemplateGenerator =>
           Dictionary(
             "serviceFuncNameForCompile" -> genID(f.funcName.toCamelCase),
             "serviceFuncNameForWire" -> v(f.originalName),
+            "__stats_name" -> genID(f.funcName.toCamelCase.prepend("__stats_")),
             "funcObjectName" -> genID(functionObjectName(f)),
             "argNames" ->
               v(f.args.map { field =>


### PR DESCRIPTION
this is already supported in client side, so I think it make sense to add it in service side.

I didn't add this in generated java code because java service didn't even take a StatsReciever as constructor parameter, so there will be a big change.