### PR TITLE
Fix nullary warning within `UnknownUnionField`.

### DIFF
--- a/scrooge-generator/src/main/resources/scalagen/union.scala
+++ b/scrooge-generator/src/main/resources/scalagen/union.scala
@@ -219,7 +219,7 @@ object {{StructName}} extends ThriftStructCodec3[{{StructName}}] {
       private val field: TFieldBlob)
     extends {{StructName}} {
 
-    def containedValue: Unit = ()
+    def containedValue(): Unit = ()
 
     def unionStructFieldInfo: _root_.scala.Option[ThriftStructFieldInfo] = _root_.scala.None
 


### PR DESCRIPTION
The `containedValue` field returns `Unit` but does not follow the standard of having parenthesis after the method name (`containedValue()`). Thus, a warning is produced:

```scala
[warn] foo.scala:240: side-effecting nullary methods are discouraged: suggest defining as `def containedValue()` instead
[warn]     def containedValue: Unit = ()
[warn]         ^
```

This fix simply adds the parenthesis to the method name.