### PR TITLE
Use explicit `java.lang.Override` annotation.

### DIFF
--- a/scrooge-generator/src/main/resources/androidgen/struct_inner.mustache
+++ b/scrooge-generator/src/main/resources/androidgen/struct_inner.mustache
@@ -85,7 +85,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     return new {{name}}(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     {{#fields}}
     {{#consolidate_newlines}}
@@ -244,7 +244,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -282,7 +282,7 @@ this.{{name}} != that.{{name}}
     return true;
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   public int hashCode() {
     {{#gen_hash_code}}
@@ -421,7 +421,7 @@ this.{{name}} != that.{{name}}
   {{/is_result}}
   {{/consolidate_newlines}}
 
-  @Override
+  @java.lang.Override
   public String toString() {
     {{#consolidate_newlines}}
     StringBuilder sb = new StringBuilder("{{name}}(");

--- a/scrooge-generator/src/main/resources/androidgen/union_inner.mustache
+++ b/scrooge-generator/src/main/resources/androidgen/union_inner.mustache
@@ -24,7 +24,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     return new {{name}}(this);
   }
 
-  @Override
+  @java.lang.Override
   protected void checkType(_Fields setField, Object value) throws ClassCastException {
     switch (setField) {
       {{#fields}}
@@ -39,7 +39,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   protected Object readValue(TProtocol iprot, TField field) throws TException {
     _Fields setField = _Fields.findByThriftId(field.id);
@@ -65,7 +65,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   protected void writeValue(TProtocol oprot) throws TException {
     switch (setField_) {
@@ -80,7 +80,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TField getFieldDesc(_Fields setField) {
     switch (setField) {
       {{#fields}}
@@ -92,12 +92,12 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TStruct getStructDesc() {
     return STRUCT_DESC;
   }
 
-  @Override
+  @java.lang.Override
   protected _Fields enumForId(short id) {
     return _Fields.findByThriftIdOrThrow(id);
   }
@@ -116,7 +116,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     return other != null && getSetField() == other.getSetField() && getFieldValue().equals(other.getFieldValue());
   }
 
-  @Override
+  @java.lang.Override
   public int compareTo({{{struct_type_name}}} other) {
     int lastComparison = TBaseHelper.compareTo(getSetField(), other.getSetField());
     if (lastComparison == 0) {
@@ -130,7 +130,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
    * If you'd like this to perform more respectably, use the hashcode generator option.
    */
   {{/gen_hash_code}}
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   public int hashCode() {
     {{#gen_hash_code}}

--- a/scrooge-generator/src/main/resources/apachejavagen/struct_inner.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/struct_inner.mustache
@@ -82,7 +82,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     return new {{name}}(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     {{#fields}}
     {{#consolidate_newlines}}
@@ -251,7 +251,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -289,7 +289,7 @@ this.{{name}} != that.{{name}}
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     {{#gen_hash_code}}
     HashCodeBuilder builder = new HashCodeBuilder();
@@ -428,7 +428,7 @@ this.{{name}} != that.{{name}}
   {{/is_result}}
   {{/consolidate_newlines}}
 
-  @Override
+  @java.lang.Override
   public String toString() {
     {{#consolidate_newlines}}
     StringBuilder sb = new StringBuilder("{{name}}(");

--- a/scrooge-generator/src/main/resources/apachejavagen/union_inner.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/union_inner.mustache
@@ -28,7 +28,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
   }
   {{/fields}}
 
-  @Override
+  @java.lang.Override
   protected void checkType(_Fields setField, Object value) throws ClassCastException {
     switch (setField) {
       {{#fields}}
@@ -43,7 +43,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   protected Object readValue(TProtocol iprot, TField field) throws TException {
     _Fields setField = _Fields.findByThriftId(field.id);
     if (setField != null) {
@@ -68,7 +68,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   protected void writeValue(TProtocol oprot) throws TException {
     switch (setField_) {
       {{#fields}}
@@ -82,7 +82,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TField getFieldDesc(_Fields setField) {
     switch (setField) {
       {{#fields}}
@@ -94,12 +94,12 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TStruct getStructDesc() {
     return STRUCT_DESC;
   }
 
-  @Override
+  @java.lang.Override
   protected _Fields enumForId(short id) {
     return _Fields.findByThriftIdOrThrow(id);
   }
@@ -136,7 +136,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
     return other != null && getSetField() == other.getSetField() && getFieldValue().equals(other.getFieldValue());
   }
 
-  @Override
+  @java.lang.Override
   public int compareTo({{{struct_type_name}}} other) {
     int lastComparison = TBaseHelper.compareTo(getSetField(), other.getSetField());
     if (lastComparison == 0) {
@@ -150,7 +150,7 @@ public {{#is_final}}final {{/is_final}}{{#in_class}}static {{/in_class}}class {{
    * If you'd like this to perform more respectably, use the hashcode generator option.
    */
   {{/gen_hash_code}}
-  @Override
+  @java.lang.Override
   public int hashCode() {
     {{#gen_hash_code}}
     HashCodeBuilder hcb = new HashCodeBuilder();

--- a/scrooge-generator/src/main/resources/javagen/struct.java
+++ b/scrooge-generator/src/main/resources/javagen/struct.java
@@ -77,7 +77,7 @@ public {{/public}}{{^public}}static {{/public}}class {{StructName}}{{#isExceptio
   }
 
   public static ThriftStructCodec<{{StructName}}> CODEC = new ThriftStructCodec3<{{StructName}}>() {
-    @Override
+    @java.lang.Override
     public {{StructName}} decode(TProtocol _iprot) throws org.apache.thrift.TException {
       Builder builder = new Builder();
 {{#fields}}
@@ -112,7 +112,7 @@ public {{/public}}{{^public}}static {{/public}}class {{StructName}}{{#isExceptio
       }
     }
 
-    @Override
+    @java.lang.Override
     public void encode({{StructName}} struct, TProtocol oprot) throws org.apache.thrift.TException {
       struct.write(oprot);
     }
@@ -195,13 +195,13 @@ public {{/public}}{{^public}}static {{/public}}class {{StructName}}{{#isExceptio
   }
 
 {{#hasExceptionMessage}}
-  @Override
+  @java.lang.Override
   public String getMessage() {
     return String.valueOf({{exceptionMessageField}});
   }
 {{/hasExceptionMessage}}
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object other) {
 {{#arity0}}
     return this == other;
@@ -225,7 +225,7 @@ public {{/public}}{{^public}}static {{/public}}class {{StructName}}{{#isExceptio
 {{/arity0}}
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
 {{#arity0}}
     return "{{StructName}}()";
@@ -235,7 +235,7 @@ public {{/public}}{{^public}}static {{/public}}class {{StructName}}{{#isExceptio
 {{/arity0}}
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
 {{#arity0}}
     return super.hashCode();

--- a/scrooge-generator/src/main/resources/javagen/union.java
+++ b/scrooge-generator/src/main/resources/javagen/union.java
@@ -138,13 +138,13 @@ UNKNOWN_UNION_VALUE;
   }
 
 {{#hasExceptionMessage}}
-  @Override
+  @java.lang.Override
   public String getMessage() {
     return String.valueOf({{exceptionMessageField}});
   }
 {{/hasExceptionMessage}}
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object other) {
 {{#arity0}}
     return this == other;
@@ -168,7 +168,7 @@ UNKNOWN_UNION_VALUE;
 {{/arity0}}
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
 {{#arity0}}
     return "{{StructName}}()";
@@ -184,7 +184,7 @@ UNKNOWN_UNION_VALUE;
 {{/arity0}}
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
 {{#arity0}}
     return super.hashCode();

--- a/scrooge-generator/src/test/resources/android_output/empty_struct.txt
+++ b/scrooge-generator/src/test/resources/android_output/empty_struct.txt
@@ -106,7 +106,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     return new FollowerTargetingDetails(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
   }
 
@@ -139,7 +139,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -155,7 +155,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     return true;
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   public int hashCode() {
     int hashCode = 1;
@@ -207,7 +207,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("FollowerTargetingDetails(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/android_output/struct_with_hashcode.txt
+++ b/scrooge-generator/src/test/resources/android_output/struct_with_hashcode.txt
@@ -332,7 +332,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     return new Work(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.num1 = 0;
     __isset_bit_vector.set(__NUM2_ISSET_ID, false);
@@ -634,7 +634,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -754,7 +754,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     return true;
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   public int hashCode() {
     int hashCode = 1;
@@ -1222,7 +1222,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("Work(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/android_output/test_exception.txt
+++ b/scrooge-generator/src/test/resources/android_output/test_exception.txt
@@ -127,7 +127,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     return new TestException(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.message = null;
   }
@@ -191,7 +191,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -216,7 +216,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -287,7 +287,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("TestException(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/android_output/test_request.txt
+++ b/scrooge-generator/src/test/resources/android_output/test_request.txt
@@ -130,7 +130,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     return new TestRequest(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     setIdIsSet(false);
     this.id = 0;
@@ -194,7 +194,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -219,7 +219,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -289,7 +289,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("TestRequest(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/android_output/union_with_hashcode.txt
+++ b/scrooge-generator/src/test/resources/android_output/union_with_hashcode.txt
@@ -124,7 +124,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     return new TestUnion(this);
   }
 
-  @Override
+  @java.lang.Override
   protected void checkType(_Fields setField, Object value) throws ClassCastException {
     switch (setField) {
       case AN_INT:
@@ -147,7 +147,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   protected Object readValue(TProtocol iprot, TField field) throws TException {
     _Fields setField = _Fields.findByThriftId(field.id);
@@ -202,7 +202,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   protected void writeValue(TProtocol oprot) throws TException {
     switch (setField_) {
@@ -233,7 +233,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TField getFieldDesc(_Fields setField) {
     switch (setField) {
       case AN_INT:
@@ -247,12 +247,12 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TStruct getStructDesc() {
     return STRUCT_DESC;
   }
 
-  @Override
+  @java.lang.Override
   protected _Fields enumForId(short id) {
     return _Fields.findByThriftIdOrThrow(id);
   }
@@ -274,7 +274,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     return other != null && getSetField() == other.getSetField() && getFieldValue().equals(other.getFieldValue());
   }
 
-  @Override
+  @java.lang.Override
   public int compareTo(TestUnion other) {
     int lastComparison = TBaseHelper.compareTo(getSetField(), other.getSetField());
     if (lastComparison == 0) {
@@ -283,7 +283,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     return lastComparison;
   }
 
-  @Override
+  @java.lang.Override
   @SuppressWarnings("unchecked")
   public int hashCode() {
     int hashCode = this.getClass().getName().hashCode();

--- a/scrooge-generator/src/test/resources/apache_output/empty_struct.txt
+++ b/scrooge-generator/src/test/resources/apache_output/empty_struct.txt
@@ -106,7 +106,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     return new FollowerTargetingDetails(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
   }
 
@@ -132,7 +132,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -148,7 +148,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -197,7 +197,7 @@ public class FollowerTargetingDetails implements TBase<FollowerTargetingDetails,
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("FollowerTargetingDetails(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/other_service.txt
+++ b/scrooge-generator/src/test/resources/apache_output/other_service.txt
@@ -466,7 +466,7 @@ public class OtherService {
     return new test_endpoint_args(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     setReqIsSet(false);
     this.req = 0;
@@ -529,7 +529,7 @@ public class OtherService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -553,7 +553,7 @@ public class OtherService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -624,7 +624,7 @@ public class OtherService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_endpoint_args(");
     boolean first = true;
@@ -745,7 +745,7 @@ public class OtherService {
     return new test_endpoint_result(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     setSuccessIsSet(false);
     this.success = false;
@@ -808,7 +808,7 @@ public class OtherService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -832,7 +832,7 @@ public class OtherService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -903,7 +903,7 @@ public class OtherService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_endpoint_result(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/struct.txt
+++ b/scrooge-generator/src/test/resources/apache_output/struct.txt
@@ -319,7 +319,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     return new Work(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.num1 = 0;
 
@@ -929,7 +929,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -1062,7 +1062,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -1488,7 +1488,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("Work(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/struct_with_hashcode.txt
+++ b/scrooge-generator/src/test/resources/apache_output/struct_with_hashcode.txt
@@ -320,7 +320,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     return new Work(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.num1 = 0;
 
@@ -930,7 +930,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -1063,7 +1063,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     HashCodeBuilder builder = new HashCodeBuilder();
 
@@ -1556,7 +1556,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("Work(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/test_exception.txt
+++ b/scrooge-generator/src/test/resources/apache_output/test_exception.txt
@@ -127,7 +127,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     return new TestException(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.message = null;
   }
@@ -191,7 +191,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -216,7 +216,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -287,7 +287,7 @@ public class TestException extends Exception implements TBase<TestException, Tes
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("TestException(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/test_request.txt
+++ b/scrooge-generator/src/test/resources/apache_output/test_request.txt
@@ -130,7 +130,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     return new TestRequest(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     setIdIsSet(false);
     this.id = 0;
@@ -194,7 +194,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -219,7 +219,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -289,7 +289,7 @@ public class TestRequest implements TBase<TestRequest, TestRequest._Fields>, jav
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("TestRequest(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/test_service.txt
+++ b/scrooge-generator/src/test/resources/apache_output/test_service.txt
@@ -638,7 +638,7 @@ public class TestService {
     return new test_endpoint_args(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.request = null;
   }
@@ -701,7 +701,7 @@ public class TestService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -725,7 +725,7 @@ public class TestService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -798,7 +798,7 @@ public class TestService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_endpoint_args(");
     boolean first = true;
@@ -935,7 +935,7 @@ public class TestService {
     return new test_endpoint_result(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     setSuccessIsSet(false);
     this.success = false;
@@ -1035,7 +1035,7 @@ public class TestService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -1067,7 +1067,7 @@ public class TestService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -1160,7 +1160,7 @@ public class TestService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_endpoint_result(");
     boolean first = true;
@@ -1287,7 +1287,7 @@ public class TestService {
     return new test_oneway_args(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.request = null;
   }
@@ -1350,7 +1350,7 @@ public class TestService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -1374,7 +1374,7 @@ public class TestService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -1447,7 +1447,7 @@ public class TestService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_oneway_args(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/test_service_without_parent.txt
+++ b/scrooge-generator/src/test/resources/apache_output/test_service_without_parent.txt
@@ -704,7 +704,7 @@ public class TestService {
     return new test_void_endpoint_args(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.request = null;
   }
@@ -767,7 +767,7 @@ public class TestService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -791,7 +791,7 @@ public class TestService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -864,7 +864,7 @@ public class TestService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_void_endpoint_args(");
     boolean first = true;
@@ -986,7 +986,7 @@ public class TestService {
     return new test_void_endpoint_result(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.ex = null;
   }
@@ -1049,7 +1049,7 @@ public class TestService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -1073,7 +1073,7 @@ public class TestService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -1144,7 +1144,7 @@ public class TestService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_void_endpoint_result(");
     boolean first = true;
@@ -1267,7 +1267,7 @@ public class TestService {
     return new test_endpoint_without_exception_args(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.request = null;
   }
@@ -1330,7 +1330,7 @@ public class TestService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -1354,7 +1354,7 @@ public class TestService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -1427,7 +1427,7 @@ public class TestService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_endpoint_without_exception_args(");
     boolean first = true;
@@ -1549,7 +1549,7 @@ public class TestService {
     return new test_endpoint_without_exception_result(this);
   }
 
-  @Override
+  @java.lang.Override
   public void clear() {
     this.success = null;
   }
@@ -1612,7 +1612,7 @@ public class TestService {
     throw new IllegalStateException();
   }
 
-  @Override
+  @java.lang.Override
   public boolean equals(Object that) {
     if (that == null)
       return false;
@@ -1636,7 +1636,7 @@ public class TestService {
     return true;
   }
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }
@@ -1707,7 +1707,7 @@ public class TestService {
     oprot.writeStructEnd();
   }
 
-  @Override
+  @java.lang.Override
   public String toString() {
     StringBuilder sb = new StringBuilder("test_endpoint_without_exception_result(");
     boolean first = true;

--- a/scrooge-generator/src/test/resources/apache_output/union.txt
+++ b/scrooge-generator/src/test/resources/apache_output/union.txt
@@ -144,7 +144,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
   }
 
 
-  @Override
+  @java.lang.Override
   protected void checkType(_Fields setField, Object value) throws ClassCastException {
     switch (setField) {
       case AN_INT:
@@ -167,7 +167,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected Object readValue(TProtocol iprot, TField field) throws TException {
     _Fields setField = _Fields.findByThriftId(field.id);
     if (setField != null) {
@@ -218,7 +218,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected void writeValue(TProtocol oprot) throws TException {
     switch (setField_) {
       case AN_INT:
@@ -245,7 +245,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TField getFieldDesc(_Fields setField) {
     switch (setField) {
       case AN_INT:
@@ -259,12 +259,12 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TStruct getStructDesc() {
     return STRUCT_DESC;
   }
 
-  @Override
+  @java.lang.Override
   protected _Fields enumForId(short id) {
     return _Fields.findByThriftIdOrThrow(id);
   }
@@ -327,7 +327,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     return other != null && getSetField() == other.getSetField() && getFieldValue().equals(other.getFieldValue());
   }
 
-  @Override
+  @java.lang.Override
   public int compareTo(TestUnion other) {
     int lastComparison = TBaseHelper.compareTo(getSetField(), other.getSetField());
     if (lastComparison == 0) {
@@ -340,7 +340,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
   /**
    * If you'd like this to perform more respectably, use the hashcode generator option.
    */
-  @Override
+  @java.lang.Override
   public int hashCode() {
     return 0;
   }

--- a/scrooge-generator/src/test/resources/apache_output/union_with_hashcode.txt
+++ b/scrooge-generator/src/test/resources/apache_output/union_with_hashcode.txt
@@ -145,7 +145,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
   }
 
 
-  @Override
+  @java.lang.Override
   protected void checkType(_Fields setField, Object value) throws ClassCastException {
     switch (setField) {
       case AN_INT:
@@ -168,7 +168,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected Object readValue(TProtocol iprot, TField field) throws TException {
     _Fields setField = _Fields.findByThriftId(field.id);
     if (setField != null) {
@@ -219,7 +219,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected void writeValue(TProtocol oprot) throws TException {
     switch (setField_) {
       case AN_INT:
@@ -246,7 +246,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TField getFieldDesc(_Fields setField) {
     switch (setField) {
       case AN_INT:
@@ -260,12 +260,12 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     }
   }
 
-  @Override
+  @java.lang.Override
   protected TStruct getStructDesc() {
     return STRUCT_DESC;
   }
 
-  @Override
+  @java.lang.Override
   protected _Fields enumForId(short id) {
     return _Fields.findByThriftIdOrThrow(id);
   }
@@ -328,7 +328,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
     return other != null && getSetField() == other.getSetField() && getFieldValue().equals(other.getFieldValue());
   }
 
-  @Override
+  @java.lang.Override
   public int compareTo(TestUnion other) {
     int lastComparison = TBaseHelper.compareTo(getSetField(), other.getSetField());
     if (lastComparison == 0) {
@@ -338,7 +338,7 @@ public class TestUnion extends TUnion<TestUnion, TestUnion._Fields> {
   }
 
 
-  @Override
+  @java.lang.Override
   public int hashCode() {
     HashCodeBuilder hcb = new HashCodeBuilder();
     hcb.append(this.getClass().getName());


### PR DESCRIPTION
Problem

Using just `@Override` has a potential for naming conflicts (e.g. `struct Override`).

Solution

Generated code uses `@java.lang.Override` instead.