### PR TITLE
Add abstract value, name, and originalName to sealed enum trait

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
@@ -30,6 +30,7 @@ case object RequestType {
 
   case class EnumUnknownRequestType(value: Int) extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
     val name = "EnumUnknownRequestType" + value
+    val originalName = "EnumUnknownRequestType" + value
   }
 
   /**
@@ -82,4 +83,8 @@ case object RequestType {
 
 
 @javax.annotation.Generated(value = Array("com.twitter.scrooge.Compiler"))
-sealed trait RequestType extends ThriftEnum with Serializable
+sealed trait RequestType extends ThriftEnum with Serializable {
+  def value: Int
+  def name: String
+  def originalName: String
+}

--- a/scrooge-generator/src/main/resources/scalagen/enum.scala
+++ b/scrooge-generator/src/main/resources/scalagen/enum.scala
@@ -18,6 +18,7 @@ case object {{EnumName}} {
 
   case class EnumUnknown{{EnumName}}(value: Int) extends {{package}}.{{EnumName}} {
     val name = "EnumUnknown{{EnumName}}" + value
+    val originalName = "EnumUnknown{{EnumName}}" + value
   }
 
   /**
@@ -74,4 +75,8 @@ case object {{EnumName}} {
 
 {{docstring}}
 @javax.annotation.Generated(value = Array("com.twitter.scrooge.Compiler"))
-sealed trait {{EnumName}} extends ThriftEnum with Serializable
+sealed trait {{EnumName}} extends ThriftEnum with Serializable {
+  def value: Int
+  def name: String
+  def originalName: String
+}


### PR DESCRIPTION
Problem

For an enum, generated case objects have a `value`, `name` and `originalName`
field, but these are inaccessible when working with the enum's sealed trait.

Solution

This adds these fields to the sealed trait so we can access them when working
with objects typed as the sealed trait.