### PR TITLE
Add originalName to ThriftEnum

### DIFF
--- a/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftEnum.scala
+++ b/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftEnum.scala
@@ -5,6 +5,6 @@ import org.apache.thrift.TEnum
 trait ThriftEnum extends TEnum {
   def value: Int
   def name: String
-  def originalName: String = name
+  def originalName: String
   def getValue = value
 }

--- a/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftEnum.scala
+++ b/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftEnum.scala
@@ -5,5 +5,6 @@ import org.apache.thrift.TEnum
 trait ThriftEnum extends TEnum {
   def value: Int
   def name: String
+  def originalName: String = name
   def getValue = value
 }

--- a/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftEnum.scala
+++ b/scrooge-core/src/main/scala/com/twitter/scrooge/ThriftEnum.scala
@@ -2,9 +2,15 @@ package com.twitter.scrooge
 
 import org.apache.thrift.TEnum
 
+
 trait ThriftEnum extends TEnum {
   def value: Int
   def name: String
+
+  /**
+    * The original name for the enum value as defined in the input Thrift IDL file.
+    */
   def originalName: String
+
   def getValue = value
 }

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
@@ -15,7 +15,7 @@ case object RequestType {
   case object Create extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
     val value = 1
     val name = "Create"
-    override val originalName = "Create"
+    val originalName = "Create"
   }
 
   private[this] val _SomeCreate = _root_.scala.Some(com.twitter.scrooge.test.gold.thriftscala.RequestType.Create)
@@ -23,14 +23,14 @@ case object RequestType {
   case object Read extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
     val value = 2
     val name = "Read"
-    override val originalName = "Read"
+    val originalName = "Read"
   }
 
   private[this] val _SomeRead = _root_.scala.Some(com.twitter.scrooge.test.gold.thriftscala.RequestType.Read)
 
   case class EnumUnknownRequestType(value: Int) extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
     val name = "EnumUnknownRequestType" + value
-    override val originalName = "EnumUnknownRequestType" + value
+    val originalName = name
   }
 
   /**

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
@@ -15,7 +15,7 @@ case object RequestType {
   case object Create extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
     val value = 1
     val name = "Create"
-    val originalName = "Create"
+    override val originalName = "Create"
   }
 
   private[this] val _SomeCreate = _root_.scala.Some(com.twitter.scrooge.test.gold.thriftscala.RequestType.Create)
@@ -23,13 +23,14 @@ case object RequestType {
   case object Read extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
     val value = 2
     val name = "Read"
-    val originalName = "Read"
+    override val originalName = "Read"
   }
 
   private[this] val _SomeRead = _root_.scala.Some(com.twitter.scrooge.test.gold.thriftscala.RequestType.Read)
 
   case class EnumUnknownRequestType(value: Int) extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
     val name = "EnumUnknownRequestType" + value
+    override val originalName = "EnumUnknownRequestType" + value
   }
 
   /**

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
@@ -13,24 +13,24 @@ import com.twitter.scrooge.ThriftEnum
 case object RequestType {
 
   case object Create extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
-    val value = 1
-    val name = "Create"
-    val originalName = "Create"
+    val value: Int = 1
+    val name: String = "Create"
+    val originalName: String = "Create"
   }
 
   private[this] val _SomeCreate = _root_.scala.Some(com.twitter.scrooge.test.gold.thriftscala.RequestType.Create)
 
   case object Read extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
-    val value = 2
-    val name = "Read"
-    val originalName = "Read"
+    val value: Int = 2
+    val name: String = "Read"
+    val originalName: String = "Read"
   }
 
   private[this] val _SomeRead = _root_.scala.Some(com.twitter.scrooge.test.gold.thriftscala.RequestType.Read)
 
   case class EnumUnknownRequestType(value: Int) extends com.twitter.scrooge.test.gold.thriftscala.RequestType {
-    val name = "EnumUnknownRequestType" + value
-    val originalName = name
+    val name: String = "EnumUnknownRequestType" + value
+    def originalName: String = name
   }
 
   /**

--- a/scrooge-generator/src/main/resources/scalagen/enum.scala
+++ b/scrooge-generator/src/main/resources/scalagen/enum.scala
@@ -10,7 +10,7 @@ case object {{EnumName}} {
   case object {{name}} extends {{package}}.{{EnumName}} {
     val value = {{value}}
     val name = "{{name}}"
-    val originalName = "{{originalName}}"
+    override val originalName = "{{originalName}}"
   }
 
   private[this] val _Some{{name}} = _root_.scala.Some({{package}}.{{EnumName}}.{{name}})
@@ -18,6 +18,7 @@ case object {{EnumName}} {
 
   case class EnumUnknown{{EnumName}}(value: Int) extends {{package}}.{{EnumName}} {
     val name = "EnumUnknown{{EnumName}}" + value
+    override val originalName = "EnumUnknown{{EnumName}}" + value
   }
 
   /**

--- a/scrooge-generator/src/main/resources/scalagen/enum.scala
+++ b/scrooge-generator/src/main/resources/scalagen/enum.scala
@@ -8,17 +8,17 @@ case object {{EnumName}} {
 {{#values}}
   {{valuedocstring}}
   case object {{name}} extends {{package}}.{{EnumName}} {
-    val value = {{value}}
-    val name = "{{name}}"
-    val originalName = "{{originalName}}"
+    val value: Int = {{value}}
+    val name: String = "{{name}}"
+    val originalName: String = "{{originalName}}"
   }
 
   private[this] val _Some{{name}} = _root_.scala.Some({{package}}.{{EnumName}}.{{name}})
 {{/values}}
 
   case class EnumUnknown{{EnumName}}(value: Int) extends {{package}}.{{EnumName}} {
-    val name = "EnumUnknown{{EnumName}}" + value
-    val originalName = name
+    val name: String = "EnumUnknown{{EnumName}}" + value
+    def originalName: String = name
   }
 
   /**

--- a/scrooge-generator/src/main/resources/scalagen/enum.scala
+++ b/scrooge-generator/src/main/resources/scalagen/enum.scala
@@ -10,7 +10,7 @@ case object {{EnumName}} {
   case object {{name}} extends {{package}}.{{EnumName}} {
     val value = {{value}}
     val name = "{{name}}"
-    override val originalName = "{{originalName}}"
+    val originalName = "{{originalName}}"
   }
 
   private[this] val _Some{{name}} = _root_.scala.Some({{package}}.{{EnumName}}.{{name}})
@@ -18,7 +18,7 @@ case object {{EnumName}} {
 
   case class EnumUnknown{{EnumName}}(value: Int) extends {{package}}.{{EnumName}} {
     val name = "EnumUnknown{{EnumName}}" + value
-    override val originalName = "EnumUnknown{{EnumName}}" + value
+    val originalName = name
   }
 
   /**


### PR DESCRIPTION
Problem

For an enum, generated case objects have an abstract name and value field, but not originalName.

Solution

Add originalName to the ThriftEnum trait and generated EnumUnknown case classes. Add default implementation of originalName to return name to avoid breaking the API.

See #224 for prior PR.