### PR TITLE
modify thrift output folder to prevent clashing with other plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ lib_managed/
 sbt-launch.jar
 .gcprof
 allocation.jar
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,16 @@ before_script:
   - ./bin/travisci
   - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION update
 
-script: 
-  - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
-  - ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+
+script: "echo no op"
+
+matrix:
+  include:
+    - scala: 2.10.6
+      # the 'scripted' sbt plugin tests are only run for 2.10
+      script: travis_retry ./sbt ++$TRAVIS_SCALA_VERSION scrooge-sbt-plugin/scripted && ./sbt ++$TRAVIS_SCALA_VERSION coverage test && ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+    - scala: 2.11.7
+      script: travis_retry ./sbt ++$TRAVIS_SCALA_VERSION coverage test && ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 
 after_success: 
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,18 @@ before_script:
   - ./bin/travisci
   - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION update
 
-
 script: "echo no op"
 
 matrix:
   include:
     - scala: 2.10.6
-      # the 'scripted' sbt plugin tests are only run for 2.10
-      script: travis_retry ./sbt ++$TRAVIS_SCALA_VERSION scrooge-sbt-plugin/scripted && ./sbt ++$TRAVIS_SCALA_VERSION coverage test && ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
-    - scala: 2.11.7
-      script: travis_retry ./sbt ++$TRAVIS_SCALA_VERSION coverage test && ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+      script: 
+        - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION clean scrooge-sbt-plugin/scripted 
+    - scala: 2.11.8
+      script: 
+        - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport 
+        - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 
 after_success: 
   - bash <(curl -s https://codecov.io/bash)
+

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -285,7 +285,7 @@ object Scrooge extends Build {
       bintrayPublishSettings ++
       buildInfoSettings ++
       scriptedSettings
-  ).settings(
+    ).settings(
       sourceGenerators in Compile <+= buildInfo,
       buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
       buildInfoPackage := "com.twitter",
@@ -301,7 +301,7 @@ object Scrooge extends Build {
         "-Dlibthrift.version=" + libthriftVersion,
         "-Dfinagle.version=" + finagleVersion
       )
-  ).dependsOn(scroogeGenerator)
+    ).dependsOn(scroogeGenerator)
 
   lazy val scroogeLinter = Project(
     id = "scrooge-linter",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,6 +9,7 @@ import sbtassembly.Plugin._
 import AssemblyKeys._
 import sbtbuildinfo.Plugin._
 import scoverage.ScoverageSbtPlugin
+import ScriptedPlugin._
 
 object Scrooge extends Build {
   val branch = Process("git" :: "rev-parse" :: "--abbrev-ref" :: "HEAD" :: Nil).!!.trim
@@ -277,7 +278,8 @@ object Scrooge extends Build {
     settings = Defaults.coreDefaultSettings ++
       settingsWithTwoTen ++
       bintrayPublishSettings ++
-      buildInfoSettings
+      buildInfoSettings ++
+      scriptedSettings
   ).settings(
       sourceGenerators in Compile <+= buildInfo,
       buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
@@ -286,7 +288,9 @@ object Scrooge extends Build {
       publishMavenStyle := false,
       repository in bintray := "sbt-plugins",
       licenses += (("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))),
-      bintrayOrganization in bintray := Some("twittercsl")
+      bintrayOrganization in bintray := Some("twittercsl"),
+      scriptedBufferLog := false,
+      scriptedLaunchOpts ++= Seq("-Dplugin.version=" + version.value)
   ).dependsOn(scroogeGenerator)
 
   lazy val scroogeLinter = Project(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -272,6 +272,11 @@ object Scrooge extends Build {
     )
   ).dependsOn(scroogeCore, scroogeGenerator % "test")
 
+  /*
+   * The sbt-plugin is tested via the 'scripted' test runner.
+   * See http://www.scala-sbt.org/0.13/docs/Testing-sbt-plugins.html for details.
+   **/
+
   lazy val scroogeSbtPlugin = Project(
     id = "scrooge-sbt-plugin",
     base = file("scrooge-sbt-plugin"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -290,7 +290,12 @@ object Scrooge extends Build {
       licenses += (("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))),
       bintrayOrganization in bintray := Some("twittercsl"),
       scriptedBufferLog := false,
-      scriptedLaunchOpts ++= Seq("-Dplugin.version=" + version.value)
+      scriptedLaunchOpts ++= Seq(
+        "-Dplugin.version=" + version.value,
+        "-Dscrooge-core.version=" + version.value,
+        "-Dlibthrift.version=" + libthriftVersion,
+        "-Dfinagle.version=" + finagleVersion
+      )
   ).dependsOn(scroogeGenerator)
 
   lazy val scroogeLinter = Project(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,6 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.2")
+
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -171,7 +171,7 @@ object ScroogeSBT extends AutoPlugin {
     scroogeDefaultJavaNamespace := "thrift",
     scroogeThriftSourceFolder <<= (sourceDirectory) { _ / "thrift" },
     scroogeThriftExternalSourceFolder <<= (target) { _ / "thrift_external" },
-    scroogeThriftOutputFolder <<= (sourceManaged) { identity },
+    scroogeThriftOutputFolder in Compile := sourceManaged.value / "thrift",
     scroogeThriftIncludeFolders <<= (scroogeThriftSourceFolder) { Seq(_) },
     scroogeThriftNamespaceMap := Map(),
     scroogeThriftDependencies := Seq(),

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -171,7 +171,7 @@ object ScroogeSBT extends AutoPlugin {
     scroogeDefaultJavaNamespace := "thrift",
     scroogeThriftSourceFolder <<= (sourceDirectory) { _ / "thrift" },
     scroogeThriftExternalSourceFolder <<= (target) { _ / "thrift_external" },
-    scroogeThriftOutputFolder in Compile := sourceManaged.value / "thrift",
+    scroogeThriftOutputFolder in Compile := (sourceManaged in Compile).value / "thrift",
     scroogeThriftIncludeFolders <<= (scroogeThriftSourceFolder) { Seq(_) },
     scroogeThriftNamespaceMap := Map(),
     scroogeThriftDependencies := Seq(),

--- a/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/build.sbt
+++ b/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/build.sbt
@@ -1,0 +1,10 @@
+
+scalaVersion := "2.11.8"
+
+enablePlugins(BuildInfoPlugin)
+
+libraryDependencies ++= Seq(
+  "org.apache.thrift" % "libthrift" % "0.8.0",
+  "com.twitter" %% "scrooge-core" % "4.6.0",
+  "com.twitter" %% "finagle-thrift" % "6.34.0"
+)

--- a/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/build.sbt
+++ b/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/build.sbt
@@ -4,7 +4,7 @@ scalaVersion := "2.11.8"
 enablePlugins(BuildInfoPlugin)
 
 libraryDependencies ++= Seq(
-  "org.apache.thrift" % "libthrift" % "0.8.0",
-  "com.twitter" %% "scrooge-core" % "4.6.0",
-  "com.twitter" %% "finagle-thrift" % "6.34.0"
+  "org.apache.thrift" % "libthrift" % sys.props("libthrift.version"),
+  "com.twitter" %% "scrooge-core" % sys.props("scrooge-core.version"),
+  "com.twitter" %% "finagle-thrift" % sys.props("finagle.version")
 )

--- a/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/project/plugins.sbt
+++ b/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/project/plugins.sbt
@@ -1,0 +1,5 @@
+
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % sys.props("plugin.version"))
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+

--- a/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/src/main/thrift/user.thrift
+++ b/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/src/main/thrift/user.thrift
@@ -1,0 +1,10 @@
+namespace java com.twitter.demo
+
+struct User {
+  1: i64 id
+  2: string name
+}
+
+service UserService {
+  User createUser(1: string name)
+}

--- a/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/test
+++ b/scrooge-sbt-plugin/src/sbt-test/scrooge/basic/test
@@ -1,0 +1,3 @@
+> compile
+$ exists target/scala-2.11/src_managed/main/thrift/com/twitter/demo/User.scala
+$ exists target/scala-2.11/src_managed/main/sbt-buildinfo/BuildInfo.scala


### PR DESCRIPTION
The current default for `scroogeThriftOutputFolder` causes compilation errors when used alongside other sbt plugins that generate source, the most common being sbt-buildinfo. This solves it by generating the code in a subfolder of the generated sources folder. This also adds scripted setup to test the sbt plugin. The test can be run with `scrooge-sbt-plugin/scripted`.