### PR TITLE
scrooge-sbt-plugin: Include generated sources in packageSrc

### DIFF
--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -285,10 +285,15 @@ object ScroogeSBT extends AutoPlugin {
     }
   }
 
+  private[this] val generatedSources = mappings in (Compile, packageSrc) ++= {
+    val thriftOutputFolder = (scroogeThriftOutputFolder in Compile).value
+    ((thriftOutputFolder ** "*") filter { _.isFile }).get pair relativeTo(thriftOutputFolder)
+  }
+
   override lazy val projectSettings =
     Seq(ivyConfigurations += thriftConfig) ++
     inConfig(Test)(genThriftSettings) ++
-    inConfig(Compile)(genThriftSettings) :+ packageThrift
+    inConfig(Compile)(genThriftSettings) :+ packageThrift :+ generatedSources
 
   @deprecated("Settings auto-imported via AutoPlugin mechanism", "2015-03-24")
   lazy val newSettings = projectSettings


### PR DESCRIPTION
Issue: https://github.com/twitter/scrooge/issues/239.

Problem

sbt-scrooge-plugin generates empty sources jar.

Solution

Include all generated sources in packageSrc.

Result

Now it is possible to browse generated sources with modern IDE.