### PR TITLE
Fix TReusableMemoryTransport reallocation on every reset

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,9 @@ as it is included in Scrooge's user's guide.
 4.x
 -----
 
+- scrooge-core: `c.t.scrooge.TReusableMemoryTransport` now uses TUnboundedByteArrayOutputStream
+  instead of TByteArrayOutputStream to avoid buffer reallocation on reset.
+
 4.8.0
 ------
 
@@ -19,7 +22,6 @@ Breaking API Changes
 * Builds are now only for Java 8 and Scala 2.11. See the
   `blog post <https://finagle.github.io/blog/2016/04/20/scala-210-and-java7/>`_
   for details. ``RB_ID=828898``
-
 
 ~~~~~
 

--- a/scrooge-benchmark/src/main/scala/com/twitter/scrooge/benchmark/TByteArrayOutputStream.scala
+++ b/scrooge-benchmark/src/main/scala/com/twitter/scrooge/benchmark/TByteArrayOutputStream.scala
@@ -1,0 +1,59 @@
+package com.twitter.scrooge.benchmark
+
+import com.twitter.scrooge.TUnboundedByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+import org.apache.thrift.TByteArrayOutputStream
+import org.openjdk.jmh.annotations._
+
+object TByteArrayOutputStreamBenchmark {
+  @State(Scope.Thread)
+  class InputState {
+    val bytes: Int = 16
+    val buf = new Array[Byte](bytes)
+  }
+
+  @State(Scope.Benchmark)
+  class TByteArrayOutputStreamState {
+    @Param(Array("1024", "10240", "51200"))
+    var initialSize: Int = 1024
+
+    var stream: TByteArrayOutputStream = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      stream = new TByteArrayOutputStream(initialSize)
+    }
+  }
+
+  @State(Scope.Benchmark)
+  class TUnboundedByteArrayOutputStreamState {
+    @Param(Array("1024", "10240", "51200"))
+    var initialSize: Int = 1024
+
+    var stream: TByteArrayOutputStream = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit = {
+      stream = new TUnboundedByteArrayOutputStream(initialSize)
+    }
+  }
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class TByteArrayOutputStreamBenchmark {
+  import TByteArrayOutputStreamBenchmark._
+
+  def run(in: Array[Byte], out: TByteArrayOutputStream): Unit = {
+    out.write(in, 0, in.size)
+    out.reset()
+  }
+
+  @Benchmark
+  def timeTByteArrayOutputStream(in: InputState, out: TByteArrayOutputStreamState) =
+    run(in.buf, out.stream)
+
+  @Benchmark
+  def timeTUnboundedByteArrayOutputStream(in: InputState, out: TUnboundedByteArrayOutputStreamState) =
+    run(in.buf, out.stream)
+}

--- a/scrooge-core/src/main/scala/com/twitter/scrooge/TReusableMemoryTransport.scala
+++ b/scrooge-core/src/main/scala/com/twitter/scrooge/TReusableMemoryTransport.scala
@@ -6,7 +6,7 @@ import org.apache.thrift.TByteArrayOutputStream
 object TReusableMemoryTransport {
 
   def apply(initialSize: Int = 512): TReusableMemoryTransport = {
-    new TReusableMemoryTransport(new TByteArrayOutputStream(initialSize))
+    new TReusableMemoryTransport(new TUnboundedByteArrayOutputStream(initialSize))
   }
 
 }

--- a/scrooge-core/src/main/scala/com/twitter/scrooge/TUnboundedByteArrayOutputStream.scala
+++ b/scrooge-core/src/main/scala/com/twitter/scrooge/TUnboundedByteArrayOutputStream.scala
@@ -1,0 +1,14 @@
+package com.twitter.scrooge
+
+import org.apache.thrift.TByteArrayOutputStream
+
+/**
+ * A version of ByteArrayOutputStream that exposes the internal buffer.
+ * It's used to replace TByteArrayOutputStream so that the internal buffer won't be reallocated
+ * on reset.
+ */
+private[scrooge] class TUnboundedByteArrayOutputStream(size: Int) extends TByteArrayOutputStream(size) {
+  override def reset(): Unit = {
+    count = 0
+  }
+}

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/TReusableMemoryTransportSpec.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/TReusableMemoryTransportSpec.scala
@@ -30,4 +30,18 @@ class TReusableMemoryTransportSpec extends Spec {
     trans.numWrittenBytes must be(5)
   }
 
+  "does not reallocate buffer on reset()" in {
+    val cap = 5
+    val trans = TReusableMemoryTransport(cap)
+
+    val stringInBytes = "abcdefghij".getBytes("UTF-8")
+    trans.write(stringInBytes)
+    trans.numWrittenBytes must be(10)
+
+    val oldBuf = trans.getArray
+    trans.reset()
+    trans.numWrittenBytes must be(0)
+    trans.getArray must be theSameInstanceAs oldBuf
+  }
+
 }


### PR DESCRIPTION
Problem

TReusableMemoryTransport is used in generated code to reduce byte[] allocation.

``` scala
  private[this] val tlReusableBuffer = new ThreadLocal[TReusableMemoryTransport] {
    override def initialValue() = TReusableMemoryTransport(512)
  }

  private[this] def reusableBuffer: TReusableMemoryTransport = {
    val buf = tlReusableBuffer.get()
    buf.reset()
    buf
  }

  private[this] val resetCounter = stats.scope("buffer").counter("resetCount")

  private[this] def resetBuffer(trans: TReusableMemoryTransport): Unit = {
    if (trans.currentCapacity > maxThriftBufferSize) {
      resetCounter.incr()
      tlReusableBuffer.remove()
    }
  }
```

However, due to [the way TByteArrayOutputStream is implemented](https://github.com/apache/thrift/blob/master/lib/java/src/org/apache/thrift/TByteArrayOutputStream.java#L46), `buf.reset()` will allocate a new underlying byte[] if current capacity exceeds the initial size (512).

The expected behavior is the underlying byte[] is only reallocated when current capacity exceeds `maxThriftBufferSize`, which is what the above `resetBuffer` method does.

Solution

Implement a `TUnboundedByteArrayOutputStream` class that doesn't do any reallocation and leave that to the `resetBuffer` method.
