### PR TITLE
Resolve self referencing types.

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_input/gold.thrift
+++ b/scrooge-generator-tests/src/test/resources/gold_file_input/gold.thrift
@@ -21,6 +21,8 @@ struct Request {
   1: list<string> aList,
   2: set<i32> aSet,
   3: map<i64, i64> aMap,
+  4: optional Request aRequest,
+  5: list<Request> subRequests
 }
 
 struct Response {

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_android/com/twitter/scrooge/test/gold/thriftandroid/Request.java
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_android/com/twitter/scrooge/test/gold/thriftandroid/Request.java
@@ -31,17 +31,23 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   private static final TField A_LIST_FIELD_DESC = new TField("aList", TType.LIST, (short)1);
   private static final TField A_SET_FIELD_DESC = new TField("aSet", TType.SET, (short)2);
   private static final TField A_MAP_FIELD_DESC = new TField("aMap", TType.MAP, (short)3);
+  private static final TField A_REQUEST_FIELD_DESC = new TField("aRequest", TType.STRUCT, (short)4);
+  private static final TField SUB_REQUESTS_FIELD_DESC = new TField("subRequests", TType.LIST, (short)5);
 
 
   private List<String> aList;
   private Set<Integer> aSet;
   private Map<Long,Long> aMap;
+  private Request aRequest;
+  private List<Request> subRequests;
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements TFieldIdEnum {
     A_LIST((short)1, "aList"),
     A_SET((short)2, "aSet"),
-    A_MAP((short)3, "aMap");
+    A_MAP((short)3, "aMap"),
+    A_REQUEST((short)4, "aRequest"),
+    SUB_REQUESTS((short)5, "subRequests");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -62,6 +68,10 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   	return A_SET;
         case 3: // A_MAP
   	return A_MAP;
+        case 4: // A_REQUEST
+  	return A_REQUEST;
+        case 5: // SUB_REQUESTS
+  	return SUB_REQUESTS;
         default:
   	return null;
       }
@@ -110,6 +120,11 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       new MapMetaData(TType.MAP,
             new FieldValueMetaData(TType.I64),
             new FieldValueMetaData(TType.I64))));
+    tmpMap.put(_Fields.A_REQUEST, new FieldMetaData("aRequest", TFieldRequirementType.OPTIONAL,
+      new StructMetaData(TType.STRUCT, Request.class)));
+    tmpMap.put(_Fields.SUB_REQUESTS, new FieldMetaData("subRequests", TFieldRequirementType.DEFAULT,
+      new ListMetaData(TType.LIST,
+                new StructMetaData(TType.STRUCT, Request.class))));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     FieldMetaData.addStructMetaDataMap(Request.class, metaDataMap);
   }
@@ -121,7 +136,9 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   public Request(
       List<String> aList,
       Set<Integer> aSet,
-      Map<Long,Long> aMap
+      Map<Long,Long> aMap,
+      Request aRequest,
+      List<Request> subRequests
   ) {
     this();
     if(aList != null) {
@@ -132,6 +149,12 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     }
     if(aMap != null) {
       this.aMap = aMap;
+    }
+    if(aRequest != null) {
+      this.aRequest = aRequest;
+    }
+    if(subRequests != null) {
+      this.subRequests = subRequests;
     }
   }
 
@@ -165,6 +188,16 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       }
       this.aMap = __this__aMap;
     }
+    if (other.isSet(_Fields.A_REQUEST)) {
+      this.aRequest = new Request(other.aRequest);
+    }
+    if (other.isSet(_Fields.SUB_REQUESTS)) {
+      List<Request> __this__subRequests = new ArrayList<Request>();
+      for (Request other_element : other.subRequests) {
+        __this__subRequests.add(new Request(other_element));
+      }
+      this.subRequests = __this__subRequests;
+    }
   }
 
   public Request deepCopy() {
@@ -176,6 +209,8 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     this.aList = null;
     this.aSet = null;
     this.aMap = null;
+    this.aRequest = null;
+    this.subRequests = null;
   }
 
   @SuppressWarnings("unchecked")
@@ -200,6 +235,17 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
           this.aSet.add((Integer)elem);
         } else {
           throw new IllegalArgumentException("Type of field " + aSet + " should be Set, but found " +  elem.getClass().toString() + " type");
+        }
+        break;
+      }
+      case SUB_REQUESTS: {
+        if (elem instanceof Request ) {
+          if (this.subRequests == null) {
+            this.subRequests = new ArrayList<Request>();
+          }
+          this.subRequests.add((Request)elem);
+        } else {
+          throw new IllegalArgumentException("Type of field " + subRequests + " should be List, but found " +  elem.getClass().toString() + " type");
         }
         break;
       }
@@ -247,6 +293,20 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
         this.aMap = (Map<Long,Long>) value;
       }
       break;
+    case A_REQUEST:
+      if (value == null) {
+        this.aRequest = null;
+      } else {
+        this.aRequest = (Request) value;
+      }
+      break;
+    case SUB_REQUESTS:
+      if (value == null) {
+        this.subRequests = null;
+      } else {
+        this.subRequests = (List<Request>) value;
+      }
+      break;
     }
   }
 
@@ -258,6 +318,10 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       return this.aSet;
     case A_MAP:
       return this.aMap;
+    case A_REQUEST:
+      return this.aRequest;
+    case SUB_REQUESTS:
+      return this.subRequests;
     }
     throw new IllegalStateException();
   }
@@ -274,6 +338,12 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       case A_MAP:
           Any rval_aMap = (Any)((Map<Long,Long>) getFieldValue(field));
           return rval_aMap;
+      case A_REQUEST:
+          Any rval_aRequest = (Any)((Request) getFieldValue(field));
+          return rval_aRequest;
+      case SUB_REQUESTS:
+          Any rval_subRequests = (Any)((List<Request>) getFieldValue(field));
+          return rval_subRequests;
       default:
         throw new IllegalStateException("Invalid field type");
     }
@@ -288,6 +358,10 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
         return aSet != null;
     case A_MAP:
         return aMap != null;
+    case A_REQUEST:
+        return aRequest != null;
+    case SUB_REQUESTS:
+        return subRequests != null;
     }
     throw new IllegalStateException();
   }
@@ -328,6 +402,22 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       if (!this.aMap.equals(that.aMap))
         return false;
     }
+    boolean this_present_aRequest = true && this.isSet(_Fields.A_REQUEST);
+    boolean that_present_aRequest = true && that.isSet(_Fields.A_REQUEST);
+    if (this_present_aRequest || that_present_aRequest) {
+      if (!(this_present_aRequest && that_present_aRequest))
+        return false;
+      if (!this.aRequest.equals(that.aRequest))
+        return false;
+    }
+    boolean this_present_subRequests = true && this.isSet(_Fields.SUB_REQUESTS);
+    boolean that_present_subRequests = true && that.isSet(_Fields.SUB_REQUESTS);
+    if (this_present_subRequests || that_present_subRequests) {
+      if (!(this_present_subRequests && that_present_subRequests))
+        return false;
+      if (!this.subRequests.equals(that.subRequests))
+        return false;
+    }
 
     return true;
   }
@@ -344,6 +434,12 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     }
     if (true && (isSet(_Fields.A_MAP))) {
         hashCode = 31 * hashCode + aMap.hashCode();
+    }
+    if (true && (isSet(_Fields.A_REQUEST))) {
+        hashCode = 31 * hashCode + aRequest.hashCode();
+    }
+    if (true && (isSet(_Fields.SUB_REQUESTS))) {
+        hashCode = 31 * hashCode + subRequests.hashCode();
     }
     return hashCode;
   }
@@ -382,6 +478,26 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     }
     if (isSet(_Fields.A_MAP)) {
       lastComparison = TBaseHelper.compareTo(this.aMap, typedOther.aMap);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = Boolean.valueOf(isSet(_Fields.A_REQUEST)).compareTo(typedOther.isSet(_Fields.A_REQUEST));
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSet(_Fields.A_REQUEST)) {
+      lastComparison = TBaseHelper.compareTo(this.aRequest, typedOther.aRequest);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = Boolean.valueOf(isSet(_Fields.SUB_REQUESTS)).compareTo(typedOther.isSet(_Fields.SUB_REQUESTS));
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSet(_Fields.SUB_REQUESTS)) {
+      lastComparison = TBaseHelper.compareTo(this.subRequests, typedOther.subRequests);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -457,6 +573,32 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
             TProtocolUtil.skip(iprot, field.type);
           }
           break;
+        case 4: // A_REQUEST
+          if (field.type == TType.STRUCT) {
+            this.aRequest = new Request();
+            this.aRequest.read(iprot);
+          } else {
+            TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case 5: // SUB_REQUESTS
+          if (field.type == TType.LIST) {
+            {
+            TList _list10 = iprot.readListBegin();
+            this.subRequests = new ArrayList<Request>(_list10.size);
+            for (int _i11 = 0; _i11 < _list10.size; ++_i11)
+            {
+              Request _elem12;
+              _elem12 = new Request();
+              _elem12.read(iprot);
+              this.subRequests.add(_elem12);
+            }
+            iprot.readListEnd();
+            }
+          } else {
+            TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
         default:
           TProtocolUtil.skip(iprot, field.type);
       }
@@ -476,9 +618,9 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       oprot.writeFieldBegin(A_LIST_FIELD_DESC);
       {
         oprot.writeListBegin(new TList(TType.STRING, this.aList.size()));
-        for (String _iter10 : this.aList)
+        for (String _iter13 : this.aList)
         {
-          oprot.writeString(_iter10);
+          oprot.writeString(_iter13);
         }
         oprot.writeListEnd();
       }
@@ -488,9 +630,9 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       oprot.writeFieldBegin(A_SET_FIELD_DESC);
       {
         oprot.writeSetBegin(new TSet(TType.I32, this.aSet.size()));
-        for (int _iter11 : this.aSet)
+        for (int _iter14 : this.aSet)
         {
-          oprot.writeI32(_iter11);
+          oprot.writeI32(_iter14);
         }
         oprot.writeSetEnd();
       }
@@ -500,12 +642,31 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       oprot.writeFieldBegin(A_MAP_FIELD_DESC);
       {
         oprot.writeMapBegin(new TMap(TType.I64, TType.I64, this.aMap.size()));
-        for (Map.Entry<Long, Long> _iter12 : this.aMap.entrySet())
+        for (Map.Entry<Long, Long> _iter15 : this.aMap.entrySet())
         {
-          oprot.writeI64(_iter12.getKey());
-          oprot.writeI64(_iter12.getValue());
+          oprot.writeI64(_iter15.getKey());
+          oprot.writeI64(_iter15.getValue());
         }
         oprot.writeMapEnd();
+      }
+      oprot.writeFieldEnd();
+    }
+    if (this.aRequest != null) {
+      if (isSet(_Fields.A_REQUEST)) {
+        oprot.writeFieldBegin(A_REQUEST_FIELD_DESC);
+        this.aRequest.write(oprot);
+        oprot.writeFieldEnd();
+      }
+    }
+    if (this.subRequests != null) {
+      oprot.writeFieldBegin(SUB_REQUESTS_FIELD_DESC);
+      {
+        oprot.writeListBegin(new TList(TType.STRUCT, this.subRequests.size()));
+        for (Request _iter16 : this.subRequests)
+        {
+          _iter16.write(oprot);
+        }
+        oprot.writeListEnd();
       }
       oprot.writeFieldEnd();
     }
@@ -540,6 +701,24 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       sb.append(this.aMap);
     }
     first = false;
+    if (isSet(_Fields.A_REQUEST)) {
+      if (!first) sb.append(", ");
+      sb.append("aRequest:");
+      if (this.aRequest == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.aRequest);
+      }
+      first = false;
+      }
+    if (!first) sb.append(", ");
+    sb.append("subRequests:");
+    if (this.subRequests == null) {
+      sb.append("null");
+    } else {
+      sb.append(this.subRequests);
+    }
+    first = false;
     sb.append(")");
     return sb.toString();
   }
@@ -551,11 +730,15 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   public static final _Fields A_LIST = _Fields.A_LIST;
   public static final _Fields A_SET = _Fields.A_SET;
   public static final _Fields A_MAP = _Fields.A_MAP;
+  public static final _Fields A_REQUEST = _Fields.A_REQUEST;
+  public static final _Fields SUB_REQUESTS = _Fields.SUB_REQUESTS;
 
   public static class Builder {
     private List<String> aList;
     private Set<Integer> aSet;
     private Map<Long,Long> aMap;
+    private Request aRequest;
+    private List<Request> subRequests;
   @SuppressWarnings("unchecked")
   public Builder set (_Fields field, Object value) {
     switch(field) {
@@ -574,6 +757,18 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       case A_MAP: {
         if (value != null) {
           this.aMap = (Map<Long,Long>) value;
+        }
+        break;
+      }
+      case A_REQUEST: {
+        if (value != null) {
+          this.aRequest = (Request) value;
+        }
+        break;
+      }
+      case SUB_REQUESTS: {
+        if (value != null) {
+          this.subRequests = (List<Request>) value;
         }
         break;
       }
@@ -608,6 +803,17 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
         }
         break;
       }
+      case SUB_REQUESTS: {
+        if (elem instanceof Request ) {
+          if (this.subRequests == null) {
+              this.subRequests = new ArrayList<Request>();
+          }
+          this.subRequests.add((Request)elem);
+        } else {
+          throw new IllegalArgumentException("Type of field " + subRequests + " should be List, but found " +  elem.getClass().toString() + " type");
+        }
+        break;
+      }
     }
     return this;
   }
@@ -630,7 +836,7 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   }
   public Request build() {
     // check for required fields
-    return new Request(aList,aSet,aMap);
+    return new Request(aList,aSet,aMap,aRequest,subRequests);
     }
   }
 }

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_cocoa/TFNTwitterThriftGoldRequest.h
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_cocoa/TFNTwitterThriftGoldRequest.h
@@ -7,7 +7,7 @@
 #import <Foundation/Foundation.h>
 
 #import "ApacheThrift/TBase.h"
-
+#import "TFNTwitterThriftGoldRequest.h"
 
 @interface TFNTwitterThriftGoldRequest : NSObject <TBase, NSCoding>
 
@@ -20,8 +20,14 @@
 @property (nonatomic, copy) NSDictionary * aMap;
 @property (nonatomic, readonly) BOOL aMapIsSet;
 
+@property (nonatomic) TFNTwitterThriftGoldRequest* aRequest;
+@property (nonatomic, readonly) BOOL aRequestIsSet;
 
-- (instancetype)initWithAList:(NSArray *)aList aSet:(NSSet *)aSet aMap:(NSDictionary *)aMap;
+@property (nonatomic, copy) NSArray * subRequests;
+@property (nonatomic, readonly) BOOL subRequestsIsSet;
+
+
+- (instancetype)initWithAList:(NSArray *)aList aSet:(NSSet *)aSet aMap:(NSDictionary *)aMap aRequest:(TFNTwitterThriftGoldRequest*)aRequest subRequests:(NSArray *)subRequests;
 - (void)read:(id<TProtocol>)inProtocol;
 - (void)write:(id<TProtocol>)outProtocol;
 

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_cocoa/TFNTwitterThriftGoldRequest.m
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_cocoa/TFNTwitterThriftGoldRequest.m
@@ -26,16 +26,22 @@
     [ms appendFormat:@"%@ ", _aSet];
     [ms appendString:@"aMap:"];
     [ms appendFormat:@"%@ ", _aMap];
+    [ms appendString:@"aRequest:"];
+    [ms appendFormat:@"%@ ", _aRequest];
+    [ms appendString:@"subRequests:"];
+    [ms appendFormat:@"%@ ", _subRequests];
     [ms appendString:@")"];
     return [NSString stringWithString:ms];
 }
 
-- (instancetype)initWithAList:(NSArray *)aList aSet:(NSSet *)aSet aMap:(NSDictionary *)aMap
+- (instancetype)initWithAList:(NSArray *)aList aSet:(NSSet *)aSet aMap:(NSDictionary *)aMap aRequest:(TFNTwitterThriftGoldRequest*)aRequest subRequests:(NSArray *)subRequests
 {
     if (self = [super init]) {
         [self setAList:aList];
         [self setASet:aSet];
         [self setAMap:aMap];
+        [self setARequest:aRequest];
+        [self setSubRequests:subRequests];
     }
 
     return self;
@@ -53,6 +59,12 @@
         if ([decoder containsValueForKey:@"3"]) {
             [self setAMap:[decoder decodeObjectForKey:@"3"]];
         }
+        if ([decoder containsValueForKey:@"4"]) {
+            [self setARequest:[decoder decodeObjectForKey:@"4"]];
+        }
+        if ([decoder containsValueForKey:@"5"]) {
+            [self setSubRequests:[decoder decodeObjectForKey:@"5"]];
+        }
     }
     return self;
 }
@@ -67,6 +79,12 @@
     }
     if (_aMapIsSet) {
         [encoder encodeObject:_aMap forKey:@"3"];
+    }
+    if (_aRequestIsSet) {
+        [encoder encodeObject:_aRequest forKey:@"4"];
+    }
+    if (_subRequestsIsSet) {
+        [encoder encodeObject:_subRequests forKey:@"5"];
     }
 }
 
@@ -86,6 +104,18 @@
 {
     _aMap = [aMap copy];
     _aMapIsSet = YES;
+}
+
+- (void)setARequest:(TFNTwitterThriftGoldRequest *)aRequest
+{
+    _aRequest = aRequest;
+    _aRequestIsSet = YES;
+}
+
+- (void)setSubRequests:(NSArray *)subRequests
+{
+    _subRequests = [subRequests copy];
+    _subRequestsIsSet = YES;
 }
 
 - (void)read:(id <TProtocol>)inProtocol
@@ -160,6 +190,37 @@
                     [TProtocolUtil skipType:fieldType onProtocol:inProtocol];
                 }
                 break;
+            case 4:
+                if (fieldType == TType_STRUCT) {
+                    TFNTwitterThriftGoldRequest* aRequest_item;
+                    aRequest_item = [[TFNTwitterThriftGoldRequest alloc] init];
+                    [aRequest_item read:inProtocol];
+                    [self setARequest:aRequest_item];
+                } else {
+                    NSLog(@"%s: field ID %i has unexpected type %i.  Skipping.", __PRETTY_FUNCTION__, fieldID, fieldType);
+                    [TProtocolUtil skipType:fieldType onProtocol:inProtocol];
+                }
+                break;
+            case 5:
+                if (fieldType == TType_LIST) {
+                    NSArray * subRequests_item;
+                    int _subRequests_item_size;
+                    [inProtocol readListBeginReturningElementType:NULL size:&_subRequests_item_size];
+                    NSMutableArray *subRequests_item_mutable = [[NSMutableArray alloc] initWithCapacity:_subRequests_item_size];
+                    for (int _subRequests_item_i = 0; _subRequests_item_i < _subRequests_item_size; ++_subRequests_item_i) {
+                        TFNTwitterThriftGoldRequest * subRequests_item_element;
+                        subRequests_item_element = [[TFNTwitterThriftGoldRequest alloc] init];
+                        [subRequests_item_element read:inProtocol];
+                        [subRequests_item_mutable addObject: subRequests_item_element];
+                    }
+                    subRequests_item = subRequests_item_mutable;
+                    [inProtocol readListEnd];
+                    [self setSubRequests:subRequests_item];
+                } else {
+                    NSLog(@"%s: field ID %i has unexpected type %i.  Skipping.", __PRETTY_FUNCTION__, fieldID, fieldType);
+                    [TProtocolUtil skipType:fieldType onProtocol:inProtocol];
+                }
+                break;
         default:
             NSLog(@"%s: unexpected field ID %i with type %i.  Skipping.", __PRETTY_FUNCTION__, fieldID, fieldType);
             [TProtocolUtil skipType:fieldType onProtocol:inProtocol];
@@ -210,6 +271,23 @@
             [outProtocol writeI64:aMap_item_value];
         }
         [outProtocol writeMapEnd];
+        [outProtocol writeFieldEnd];
+    }
+    if (_aRequestIsSet) {
+        [outProtocol writeFieldBeginWithName:@"aRequest" type:TType_STRUCT fieldID:4];
+        TFNTwitterThriftGoldRequest* aRequest_item = _aRequest;
+        [aRequest_item write: outProtocol];
+        [outProtocol writeFieldEnd];
+    }
+    if (_subRequestsIsSet) {
+        [outProtocol writeFieldBeginWithName:@"subRequests" type:TType_LIST fieldID:5];
+        NSArray * subRequests_item = _subRequests;
+        [outProtocol writeListBeginWithElementType:TType_STRUCT size:(int)[subRequests_item count]];
+        for (int _subRequests_item_i = 0; _subRequests_item_i < [subRequests_item count]; _subRequests_item_i++) {
+            TFNTwitterThriftGoldRequest * subRequests_item_element = subRequests_item[_subRequests_item_i];
+            [subRequests_item_element write: outProtocol];
+        }
+        [outProtocol writeListEnd];
         [outProtocol writeFieldEnd];
     }
     [outProtocol writeFieldStop];

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_java/com/twitter/scrooge/test/gold/thriftjava/Request.java
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_java/com/twitter/scrooge/test/gold/thriftjava/Request.java
@@ -35,17 +35,23 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   private static final TField A_LIST_FIELD_DESC = new TField("aList", TType.LIST, (short)1);
   private static final TField A_SET_FIELD_DESC = new TField("aSet", TType.SET, (short)2);
   private static final TField A_MAP_FIELD_DESC = new TField("aMap", TType.MAP, (short)3);
+  private static final TField A_REQUEST_FIELD_DESC = new TField("aRequest", TType.STRUCT, (short)4);
+  private static final TField SUB_REQUESTS_FIELD_DESC = new TField("subRequests", TType.LIST, (short)5);
 
 
   public List<String> aList;
   public Set<Integer> aSet;
   public Map<Long,Long> aMap;
+  public Request aRequest;
+  public List<Request> subRequests;
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements TFieldIdEnum {
     A_LIST((short)1, "aList"),
     A_SET((short)2, "aSet"),
-    A_MAP((short)3, "aMap");
+    A_MAP((short)3, "aMap"),
+    A_REQUEST((short)4, "aRequest"),
+    SUB_REQUESTS((short)5, "subRequests");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -66,6 +72,10 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   	return A_SET;
         case 3: // A_MAP
   	return A_MAP;
+        case 4: // A_REQUEST
+  	return A_REQUEST;
+        case 5: // SUB_REQUESTS
+  	return SUB_REQUESTS;
         default:
   	return null;
       }
@@ -121,6 +131,11 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       new MapMetaData(TType.MAP,
             new FieldValueMetaData(TType.I64),
             new FieldValueMetaData(TType.I64))));
+    tmpMap.put(_Fields.A_REQUEST, new FieldMetaData("aRequest", TFieldRequirementType.OPTIONAL,
+      new StructMetaData(TType.STRUCT, Request.class)));
+    tmpMap.put(_Fields.SUB_REQUESTS, new FieldMetaData("subRequests", TFieldRequirementType.DEFAULT,
+      new ListMetaData(TType.LIST,
+                new StructMetaData(TType.STRUCT, Request.class))));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     FieldMetaData.addStructMetaDataMap(Request.class, metaDataMap);
   }
@@ -132,12 +147,14 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
   public Request(
     List<String> aList,
     Set<Integer> aSet,
-    Map<Long,Long> aMap)
+    Map<Long,Long> aMap,
+    List<Request> subRequests)
   {
     this();
     this.aList = aList;
     this.aSet = aSet;
     this.aMap = aMap;
+    this.subRequests = subRequests;
   }
 
   /**
@@ -169,6 +186,16 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       }
       this.aMap = __this__aMap;
     }
+    if (other.isSetARequest()) {
+      this.aRequest = new Request(other.aRequest);
+    }
+    if (other.isSetSubRequests()) {
+      List<Request> __this__subRequests = new ArrayList<Request>();
+      for (Request other_element : other.subRequests) {
+        __this__subRequests.add(new Request(other_element));
+      }
+      this.subRequests = __this__subRequests;
+    }
   }
 
   public Request deepCopy() {
@@ -180,6 +207,8 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     this.aList = null;
     this.aSet = null;
     this.aMap = null;
+    this.aRequest = null;
+    this.subRequests = null;
   }
 
   public int getAListSize() {
@@ -298,6 +327,71 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     }
   }
 
+  public Request getARequest() {
+    return this.aRequest;
+  }
+
+  public Request setARequest(Request aRequest) {
+    this.aRequest = aRequest;
+
+    return this;
+  }
+
+  public void unsetARequest() {
+    this.aRequest = null;
+  }
+
+  /** Returns true if field aRequest is set (has been asigned a value) and false otherwise */
+  public boolean isSetARequest() {
+    return this.aRequest != null;
+  }
+
+  public void setARequestIsSet(boolean value) {
+    if (!value) {
+      this.aRequest = null;
+    }
+  }
+
+  public int getSubRequestsSize() {
+    return (this.subRequests == null) ? 0 : this.subRequests.size();
+  }
+
+  public java.util.Iterator<Request> getSubRequestsIterator() {
+    return (this.subRequests == null) ? null : this.subRequests.iterator();
+  }
+
+  public void addToSubRequests(Request elem) {
+    if (this.subRequests == null) {
+      this.subRequests = new ArrayList<Request>();
+    }
+    this.subRequests.add(elem);
+  }
+
+  public List<Request> getSubRequests() {
+    return this.subRequests;
+  }
+
+  public Request setSubRequests(List<Request> subRequests) {
+    this.subRequests = subRequests;
+
+    return this;
+  }
+
+  public void unsetSubRequests() {
+    this.subRequests = null;
+  }
+
+  /** Returns true if field subRequests is set (has been asigned a value) and false otherwise */
+  public boolean isSetSubRequests() {
+    return this.subRequests != null;
+  }
+
+  public void setSubRequestsIsSet(boolean value) {
+    if (!value) {
+      this.subRequests = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case A_LIST:
@@ -321,6 +415,20 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
         setAMap((Map<Long,Long>)value);
       }
       break;
+    case A_REQUEST:
+      if (value == null) {
+        unsetARequest();
+      } else {
+        setARequest((Request)value);
+      }
+      break;
+    case SUB_REQUESTS:
+      if (value == null) {
+        unsetSubRequests();
+      } else {
+        setSubRequests((List<Request>)value);
+      }
+      break;
     }
   }
 
@@ -332,6 +440,10 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       return getASet();
     case A_MAP:
       return getAMap();
+    case A_REQUEST:
+      return getARequest();
+    case SUB_REQUESTS:
+      return getSubRequests();
     }
     throw new IllegalStateException();
   }
@@ -349,6 +461,10 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       return isSetASet();
     case A_MAP:
       return isSetAMap();
+    case A_REQUEST:
+      return isSetARequest();
+    case SUB_REQUESTS:
+      return isSetSubRequests();
     }
     throw new IllegalStateException();
   }
@@ -389,6 +505,22 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       if (!this.aMap.equals(that.aMap))
         return false;
     }
+    boolean this_present_aRequest = true && this.isSetARequest();
+    boolean that_present_aRequest = true && that.isSetARequest();
+    if (this_present_aRequest || that_present_aRequest) {
+      if (!(this_present_aRequest && that_present_aRequest))
+        return false;
+      if (!this.aRequest.equals(that.aRequest))
+        return false;
+    }
+    boolean this_present_subRequests = true && this.isSetSubRequests();
+    boolean that_present_subRequests = true && that.isSetSubRequests();
+    if (this_present_subRequests || that_present_subRequests) {
+      if (!(this_present_subRequests && that_present_subRequests))
+        return false;
+      if (!this.subRequests.equals(that.subRequests))
+        return false;
+    }
 
     return true;
   }
@@ -408,6 +540,14 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     builder.append(present_aMap);
     if (present_aMap)
       builder.append(aMap);
+    boolean present_aRequest = true && (isSetARequest());
+    builder.append(present_aRequest);
+    if (present_aRequest)
+      builder.append(aRequest);
+    boolean present_subRequests = true && (isSetSubRequests());
+    builder.append(present_subRequests);
+    if (present_subRequests)
+      builder.append(subRequests);
     return builder.toHashCode();
   }
 
@@ -445,6 +585,26 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
     }
     if (isSetAMap()) {
       lastComparison = TBaseHelper.compareTo(this.aMap, typedOther.aMap);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = Boolean.valueOf(isSetARequest()).compareTo(typedOther.isSetARequest());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetARequest()) {
+      lastComparison = TBaseHelper.compareTo(this.aRequest, typedOther.aRequest);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = Boolean.valueOf(isSetSubRequests()).compareTo(typedOther.isSetSubRequests());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetSubRequests()) {
+      lastComparison = TBaseHelper.compareTo(this.subRequests, typedOther.subRequests);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -520,6 +680,32 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
             TProtocolUtil.skip(iprot, field.type);
           }
           break;
+        case 4: // A_REQUEST
+          if (field.type == TType.STRUCT) {
+            this.aRequest = new Request();
+            this.aRequest.read(iprot);
+          } else {
+            TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case 5: // SUB_REQUESTS
+          if (field.type == TType.LIST) {
+            {
+            TList _list10 = iprot.readListBegin();
+            this.subRequests = new ArrayList<Request>(_list10.size);
+            for (int _i11 = 0; _i11 < _list10.size; ++_i11)
+            {
+              Request _elem12;
+              _elem12 = new Request();
+              _elem12.read(iprot);
+              this.subRequests.add(_elem12);
+            }
+            iprot.readListEnd();
+            }
+          } else {
+            TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
         default:
           TProtocolUtil.skip(iprot, field.type);
       }
@@ -539,9 +725,9 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       oprot.writeFieldBegin(A_LIST_FIELD_DESC);
       {
         oprot.writeListBegin(new TList(TType.STRING, this.aList.size()));
-        for (String _iter10 : this.aList)
+        for (String _iter13 : this.aList)
         {
-          oprot.writeString(_iter10);
+          oprot.writeString(_iter13);
         }
         oprot.writeListEnd();
       }
@@ -551,9 +737,9 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       oprot.writeFieldBegin(A_SET_FIELD_DESC);
       {
         oprot.writeSetBegin(new TSet(TType.I32, this.aSet.size()));
-        for (int _iter11 : this.aSet)
+        for (int _iter14 : this.aSet)
         {
-          oprot.writeI32(_iter11);
+          oprot.writeI32(_iter14);
         }
         oprot.writeSetEnd();
       }
@@ -563,12 +749,31 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       oprot.writeFieldBegin(A_MAP_FIELD_DESC);
       {
         oprot.writeMapBegin(new TMap(TType.I64, TType.I64, this.aMap.size()));
-        for (Map.Entry<Long, Long> _iter12 : this.aMap.entrySet())
+        for (Map.Entry<Long, Long> _iter15 : this.aMap.entrySet())
         {
-          oprot.writeI64(_iter12.getKey());
-          oprot.writeI64(_iter12.getValue());
+          oprot.writeI64(_iter15.getKey());
+          oprot.writeI64(_iter15.getValue());
         }
         oprot.writeMapEnd();
+      }
+      oprot.writeFieldEnd();
+    }
+    if (this.aRequest != null) {
+      if (isSetARequest()) {
+        oprot.writeFieldBegin(A_REQUEST_FIELD_DESC);
+        this.aRequest.write(oprot);
+        oprot.writeFieldEnd();
+      }
+    }
+    if (this.subRequests != null) {
+      oprot.writeFieldBegin(SUB_REQUESTS_FIELD_DESC);
+      {
+        oprot.writeListBegin(new TList(TType.STRUCT, this.subRequests.size()));
+        for (Request _iter16 : this.subRequests)
+        {
+          _iter16.write(oprot);
+        }
+        oprot.writeListEnd();
       }
       oprot.writeFieldEnd();
     }
@@ -601,6 +806,24 @@ public class Request implements TBase<Request, Request._Fields>, java.io.Seriali
       sb.append("null");
     } else {
       sb.append(this.aMap);
+    }
+    first = false;
+    if (isSetARequest()) {
+      if (!first) sb.append(", ");
+      sb.append("aRequest:");
+      if (this.aRequest == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.aRequest);
+      }
+      first = false;
+      }
+    if (!first) sb.append(", ");
+    sb.append("subRequests:");
+    if (this.subRequests == null) {
+      sb.append("null");
+    } else {
+      sb.append(this.subRequests);
     }
     first = false;
     sb.append(")");

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Request.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Request.scala
@@ -38,6 +38,10 @@ object Request extends ThriftStructCodec3[Request] {
   val ASetFieldManifest = implicitly[Manifest[Set[Int]]]
   val AMapField = new TField("aMap", TType.MAP, 3)
   val AMapFieldManifest = implicitly[Manifest[Map[Long, Long]]]
+  val ARequestField = new TField("aRequest", TType.STRUCT, 4)
+  val ARequestFieldManifest = implicitly[Manifest[com.twitter.scrooge.test.gold.thriftscala.Request]]
+  val SubRequestsField = new TField("subRequests", TType.LIST, 5)
+  val SubRequestsFieldManifest = implicitly[Manifest[Seq[com.twitter.scrooge.test.gold.thriftscala.Request]]]
 
   /**
    * Field information in declaration order.
@@ -75,6 +79,28 @@ object Request extends ThriftStructCodec3[Request] {
       immutable$Map.empty[String, String],
       immutable$Map.empty[String, String],
       Some[Map[Long, Long]](Map[Long, Long]())
+    ),
+    new ThriftStructFieldInfo(
+      ARequestField,
+      true,
+      false,
+      ARequestFieldManifest,
+      _root_.scala.None,
+      _root_.scala.None,
+      immutable$Map.empty[String, String],
+      immutable$Map.empty[String, String],
+      None
+    ),
+    new ThriftStructFieldInfo(
+      SubRequestsField,
+      false,
+      false,
+      SubRequestsFieldManifest,
+      _root_.scala.None,
+      _root_.scala.Some(implicitly[Manifest[com.twitter.scrooge.test.gold.thriftscala.Request]]),
+      immutable$Map.empty[String, String],
+      immutable$Map.empty[String, String],
+      Some[Seq[com.twitter.scrooge.test.gold.thriftscala.Request]](Seq[com.twitter.scrooge.test.gold.thriftscala.Request]())
     )
   )
 
@@ -121,6 +147,20 @@ object Request extends ThriftStructCodec3[Request] {
 
             newKey -> newValue
           }
+        },
+      aRequest =
+        {
+          val field = original.aRequest
+          field.map { field =>
+            com.twitter.scrooge.test.gold.thriftscala.Request.withoutPassthroughFields(field)
+          }
+        },
+      subRequests =
+        {
+          val field = original.subRequests
+          field.map { field =>
+            com.twitter.scrooge.test.gold.thriftscala.Request.withoutPassthroughFields(field)
+          }
         }
     )
 
@@ -133,6 +173,8 @@ object Request extends ThriftStructCodec3[Request] {
     var aList: Seq[String] = Seq[String]()
     var aSet: Set[Int] = Set[Int]()
     var aMap: Map[Long, Long] = Map[Long, Long]()
+    var aRequest: Option[com.twitter.scrooge.test.gold.thriftscala.Request] = None
+    var subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = Seq[com.twitter.scrooge.test.gold.thriftscala.Request]()
 
     var _passthroughFields: Builder[(Short, TFieldBlob), immutable$Map[Short, TFieldBlob]] = null
     var _done = false
@@ -187,6 +229,34 @@ object Request extends ThriftStructCodec3[Request] {
                   )
                 )
             }
+          case 4 =>
+            _field.`type` match {
+              case TType.STRUCT =>
+
+                aRequest = Some(readARequestValue(_iprot))
+              case _actualType =>
+                val _expectedType = TType.STRUCT
+                throw new TProtocolException(
+                  "Received wrong type for field 'aRequest' (expected=%s, actual=%s).".format(
+                    ttypeToString(_expectedType),
+                    ttypeToString(_actualType)
+                  )
+                )
+            }
+          case 5 =>
+            _field.`type` match {
+              case TType.LIST =>
+
+                subRequests = readSubRequestsValue(_iprot)
+              case _actualType =>
+                val _expectedType = TType.LIST
+                throw new TProtocolException(
+                  "Received wrong type for field 'subRequests' (expected=%s, actual=%s).".format(
+                    ttypeToString(_expectedType),
+                    ttypeToString(_actualType)
+                  )
+                )
+            }
           case _ =>
             if (_passthroughFields == null)
               _passthroughFields = immutable$Map.newBuilder[Short, TFieldBlob]
@@ -205,6 +275,8 @@ object Request extends ThriftStructCodec3[Request] {
       aList,
       aSet,
       aMap,
+      aRequest,
+      subRequests,
       if (_passthroughFields == null)
         NoPassthroughFields
       else
@@ -222,6 +294,8 @@ object Request extends ThriftStructCodec3[Request] {
     var aList: Seq[String] = Seq[String]()
     var aSet: Set[Int] = Set[Int]()
     var aMap: Map[Long, Long] = Map[Long, Long]()
+    var aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.None
+    var subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = Seq[com.twitter.scrooge.test.gold.thriftscala.Request]()
     var _passthroughFields: Builder[(Short, TFieldBlob), immutable$Map[Short, TFieldBlob]] = null
     var _done = false
 
@@ -271,6 +345,32 @@ object Request extends ThriftStructCodec3[Request] {
                   )
                 )
             }
+          case 4 =>
+            _field.`type` match {
+              case TType.STRUCT =>
+                aRequest = _root_.scala.Some(readARequestValue(_iprot))
+              case _actualType =>
+                val _expectedType = TType.STRUCT
+                throw new TProtocolException(
+                  "Received wrong type for field 'aRequest' (expected=%s, actual=%s).".format(
+                    ttypeToString(_expectedType),
+                    ttypeToString(_actualType)
+                  )
+                )
+            }
+          case 5 =>
+            _field.`type` match {
+              case TType.LIST =>
+                subRequests = readSubRequestsValue(_iprot)
+              case _actualType =>
+                val _expectedType = TType.LIST
+                throw new TProtocolException(
+                  "Received wrong type for field 'subRequests' (expected=%s, actual=%s).".format(
+                    ttypeToString(_expectedType),
+                    ttypeToString(_actualType)
+                  )
+                )
+            }
           case _ =>
             if (_passthroughFields == null)
               _passthroughFields = immutable$Map.newBuilder[Short, TFieldBlob]
@@ -285,6 +385,8 @@ object Request extends ThriftStructCodec3[Request] {
       aList,
       aSet,
       aMap,
+      aRequest,
+      subRequests,
       if (_passthroughFields == null)
         NoPassthroughFields
       else
@@ -295,15 +397,19 @@ object Request extends ThriftStructCodec3[Request] {
   def apply(
     aList: Seq[String] = Seq[String](),
     aSet: Set[Int] = Set[Int](),
-    aMap: Map[Long, Long] = Map[Long, Long]()
+    aMap: Map[Long, Long] = Map[Long, Long](),
+    aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.None,
+    subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = Seq[com.twitter.scrooge.test.gold.thriftscala.Request]()
   ): Request =
     new Immutable(
       aList,
       aSet,
-      aMap
+      aMap,
+      aRequest,
+      subRequests
     )
 
-  def unapply(_item: Request): _root_.scala.Option[scala.Product3[Seq[String], Set[Int], Map[Long, Long]]] = _root_.scala.Some(_item)
+  def unapply(_item: Request): _root_.scala.Option[scala.Product5[Seq[String], Set[Int], Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], Seq[com.twitter.scrooge.test.gold.thriftscala.Request]]] = _root_.scala.Some(_item)
 
 
   @inline private def readAListValue(_iprot: TProtocol): Seq[String] = {
@@ -421,6 +527,64 @@ object Request extends ThriftStructCodec3[Request] {
     _oprot.writeMapEnd()
   }
 
+  @inline private def readARequestValue(_iprot: TProtocol): com.twitter.scrooge.test.gold.thriftscala.Request = {
+    com.twitter.scrooge.test.gold.thriftscala.Request.decode(_iprot)
+  }
+
+  @inline private def writeARequestField(aRequest_item: com.twitter.scrooge.test.gold.thriftscala.Request, _oprot: TProtocol): Unit = {
+    _oprot.writeFieldBegin(ARequestField)
+    writeARequestValue(aRequest_item, _oprot)
+    _oprot.writeFieldEnd()
+  }
+
+  @inline private def writeARequestValue(aRequest_item: com.twitter.scrooge.test.gold.thriftscala.Request, _oprot: TProtocol): Unit = {
+    aRequest_item.write(_oprot)
+  }
+
+  @inline private def readSubRequestsValue(_iprot: TProtocol): Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = {
+    val _list = _iprot.readListBegin()
+    if (_list.size == 0) {
+      _iprot.readListEnd()
+      Nil
+    } else {
+      val _rv = new mutable$ArrayBuffer[com.twitter.scrooge.test.gold.thriftscala.Request](_list.size)
+      var _i = 0
+      while (_i < _list.size) {
+        _rv += {
+          com.twitter.scrooge.test.gold.thriftscala.Request.decode(_iprot)
+        }
+        _i += 1
+      }
+      _iprot.readListEnd()
+      _rv
+    }
+  }
+
+  @inline private def writeSubRequestsField(subRequests_item: Seq[com.twitter.scrooge.test.gold.thriftscala.Request], _oprot: TProtocol): Unit = {
+    _oprot.writeFieldBegin(SubRequestsField)
+    writeSubRequestsValue(subRequests_item, _oprot)
+    _oprot.writeFieldEnd()
+  }
+
+  @inline private def writeSubRequestsValue(subRequests_item: Seq[com.twitter.scrooge.test.gold.thriftscala.Request], _oprot: TProtocol): Unit = {
+    _oprot.writeListBegin(new TList(TType.STRUCT, subRequests_item.size))
+    subRequests_item match {
+      case _: IndexedSeq[_] =>
+        var _i = 0
+        val _size = subRequests_item.size
+        while (_i < _size) {
+          val subRequests_item_element = subRequests_item(_i)
+          subRequests_item_element.write(_oprot)
+          _i += 1
+        }
+      case _ =>
+        subRequests_item.foreach { subRequests_item_element =>
+          subRequests_item_element.write(_oprot)
+        }
+    }
+    _oprot.writeListEnd()
+  }
+
 
   object Immutable extends ThriftStructCodec3[Request] {
     override def encode(_item: Request, _oproto: TProtocol): Unit = { _item.write(_oproto) }
@@ -437,16 +601,22 @@ object Request extends ThriftStructCodec3[Request] {
       val aList: Seq[String],
       val aSet: Set[Int],
       val aMap: Map[Long, Long],
+      val aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request],
+      val subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request],
       override val _passthroughFields: immutable$Map[Short, TFieldBlob])
     extends Request {
     def this(
       aList: Seq[String] = Seq[String](),
       aSet: Set[Int] = Set[Int](),
-      aMap: Map[Long, Long] = Map[Long, Long]()
+      aMap: Map[Long, Long] = Map[Long, Long](),
+      aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.None,
+      subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = Seq[com.twitter.scrooge.test.gold.thriftscala.Request]()
     ) = this(
       aList,
       aSet,
       aMap,
+      aRequest,
+      subRequests,
       Map.empty
     )
   }
@@ -463,6 +633,8 @@ object Request extends ThriftStructCodec3[Request] {
       val aList: Seq[String],
       val aSet: Set[Int],
       val aMap: Map[Long, Long],
+      val aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request],
+      val subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request],
       override val _passthroughFields: immutable$Map[Short, TFieldBlob])
     extends Request {
 
@@ -498,13 +670,15 @@ object Request extends ThriftStructCodec3[Request] {
     override def aList: Seq[String] = _underlying_Request.aList
     override def aSet: Set[Int] = _underlying_Request.aSet
     override def aMap: Map[Long, Long] = _underlying_Request.aMap
+    override def aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = _underlying_Request.aRequest
+    override def subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = _underlying_Request.subRequests
     override def _passthroughFields = _underlying_Request._passthroughFields
   }
 }
 
 trait Request
   extends ThriftStruct
-  with scala.Product3[Seq[String], Set[Int], Map[Long, Long]]
+  with scala.Product5[Seq[String], Set[Int], Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], Seq[com.twitter.scrooge.test.gold.thriftscala.Request]]
   with HasThriftStructCodec3[Request]
   with java.io.Serializable
 {
@@ -513,12 +687,16 @@ trait Request
   def aList: Seq[String]
   def aSet: Set[Int]
   def aMap: Map[Long, Long]
+  def aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request]
+  def subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request]
 
   def _passthroughFields: immutable$Map[Short, TFieldBlob] = immutable$Map.empty
 
   def _1 = aList
   def _2 = aSet
   def _3 = aMap
+  def _4 = aRequest
+  def _5 = subRequests
 
 
   /**
@@ -555,6 +733,20 @@ trait Request
               } else {
                 _root_.scala.None
               }
+            case 4 =>
+              if (aRequest.isDefined) {
+                writeARequestValue(aRequest.get, _oprot)
+                _root_.scala.Some(Request.ARequestField)
+              } else {
+                _root_.scala.None
+              }
+            case 5 =>
+              if (subRequests ne null) {
+                writeSubRequestsValue(subRequests, _oprot)
+                _root_.scala.Some(Request.SubRequestsField)
+              } else {
+                _root_.scala.None
+              }
             case _ => _root_.scala.None
           }
         _fieldOpt match {
@@ -584,6 +776,8 @@ trait Request
     var aList: Seq[String] = this.aList
     var aSet: Set[Int] = this.aSet
     var aMap: Map[Long, Long] = this.aMap
+    var aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = this.aRequest
+    var subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = this.subRequests
     var _passthroughFields = this._passthroughFields
     _blob.id match {
       case 1 =>
@@ -592,12 +786,18 @@ trait Request
         aSet = readASetValue(_blob.read)
       case 3 =>
         aMap = readAMapValue(_blob.read)
+      case 4 =>
+        aRequest = _root_.scala.Some(readARequestValue(_blob.read))
+      case 5 =>
+        subRequests = readSubRequestsValue(_blob.read)
       case _ => _passthroughFields += (_blob.id -> _blob)
     }
     new Immutable(
       aList,
       aSet,
       aMap,
+      aRequest,
+      subRequests,
       _passthroughFields
     )
   }
@@ -611,6 +811,8 @@ trait Request
     var aList: Seq[String] = this.aList
     var aSet: Set[Int] = this.aSet
     var aMap: Map[Long, Long] = this.aMap
+    var aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = this.aRequest
+    var subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = this.subRequests
 
     _fieldId match {
       case 1 =>
@@ -619,12 +821,18 @@ trait Request
         aSet = Set[Int]()
       case 3 =>
         aMap = Map[Long, Long]()
+      case 4 =>
+        aRequest = _root_.scala.None
+      case 5 =>
+        subRequests = Seq[com.twitter.scrooge.test.gold.thriftscala.Request]()
       case _ =>
     }
     new Immutable(
       aList,
       aSet,
       aMap,
+      aRequest,
+      subRequests,
       _passthroughFields - _fieldId
     )
   }
@@ -640,6 +848,10 @@ trait Request
 
   def unsetAMap: Request = unsetField(3)
 
+  def unsetARequest: Request = unsetField(4)
+
+  def unsetSubRequests: Request = unsetField(5)
+
 
   override def write(_oprot: TProtocol): Unit = {
     Request.validate(this)
@@ -647,6 +859,8 @@ trait Request
     if (aList ne null) writeAListField(aList, _oprot)
     if (aSet ne null) writeASetField(aSet, _oprot)
     if (aMap ne null) writeAMapField(aMap, _oprot)
+    if (aRequest.isDefined) writeARequestField(aRequest.get, _oprot)
+    if (subRequests ne null) writeSubRequestsField(subRequests, _oprot)
     if (_passthroughFields.nonEmpty) {
       _passthroughFields.values.foreach { _.write(_oprot) }
     }
@@ -658,12 +872,16 @@ trait Request
     aList: Seq[String] = this.aList,
     aSet: Set[Int] = this.aSet,
     aMap: Map[Long, Long] = this.aMap,
+    aRequest: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = this.aRequest,
+    subRequests: Seq[com.twitter.scrooge.test.gold.thriftscala.Request] = this.subRequests,
     _passthroughFields: immutable$Map[Short, TFieldBlob] = this._passthroughFields
   ): Request =
     new Immutable(
       aList,
       aSet,
       aMap,
+      aRequest,
+      subRequests,
       _passthroughFields
     )
 
@@ -679,12 +897,14 @@ trait Request
   override def toString: String = _root_.scala.runtime.ScalaRunTime._toString(this)
 
 
-  override def productArity: Int = 3
+  override def productArity: Int = 5
 
   override def productElement(n: Int): Any = n match {
     case 0 => this.aList
     case 1 => this.aSet
     case 2 => this.aMap
+    case 3 => this.aRequest
+    case 4 => this.subRequests
     case _ => throw new IndexOutOfBoundsException(n.toString)
   }
 

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/frontend/TypeResolverSpec.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/frontend/TypeResolverSpec.scala
@@ -54,6 +54,38 @@ class TypeResolverSpec extends Spec {
       }
     }
 
+    "resolve self-referencing types" in {
+      val input =
+        """struct S {
+          |  1: i32 a,
+          |  2: string b,
+          |  3: optional S s
+          |}
+          |
+          |struct Node {
+          |  1: list<Node> children,
+          |  2: i32 data
+          |}
+        """.stripMargin
+      resolve(input)
+    }
+
+    "does not resolve non-self-referencing recursive types" in {
+      intercept[TypeNotFoundException] {
+        val input =
+          """struct Foo {
+            |  1: i32 a,
+            |  2: optional Bar b
+            |}
+            |
+            |struct Bar {
+            |  1: optional Foo f
+            |}
+          """.stripMargin
+        resolve(input)
+      }
+    }
+
     "transform MapType" in {
       resolver(MapType(enumRef, structRef, None)) match {
         case MapType(enumType, structType, None) =>

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/goldfile/GoldFileTest.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/goldfile/GoldFileTest.scala
@@ -96,27 +96,27 @@ abstract class GoldFileTest extends FunSuite
       val expected = goldDataFor(suffix)
       withClue(suffix) {
         if (genStr != expected) {
-          val genLength = genStr.length
           val diff = {
             var i = 0
-            while (i < math.min(genLength, expected.length) && genStr(i) == expected(i)) {
+            while (i < math.min(genStr.length, expected.length) && genStr(i) == expected(i)) {
               i += 1
             }
             val surround = 50
+            val longerStr = if (genStr.length >= expected.length) genStr else expected
             val substring =
-              genStr.substring(math.max(0, i - surround), i) ++
-              s"|->${genStr(i)}<-|" ++
-              genStr.substring(math.min(i + 1, genLength), math.min(i + surround, genLength))
+              longerStr.substring(math.max(0, i - surround), i) ++
+              s"|->${longerStr(i)}<-|" ++
+              longerStr.substring(math.min(i + 1, longerStr.length), math.min(i + surround, longerStr.length))
 
             s"The difference is at character $i: " +
-              s"($substring). line: ${ genStr.substring(0, i).count(_ == '\n') + 1 }"
+              s"($substring). line: ${ longerStr.substring(0, i).count(_ == '\n') + 1 }"
           }
 
           val msg =
             s"""
                |The generated file ${gen.getName} did not match gold file
                |"scrooge/scrooge-generator-tests/src/test/resources/gold_file_output_$language/$suffix".
-               |Generated string is ${genLength} characters long
+               |Generated string is ${genStr.length} characters long
                |Expected string is ${expected.length} characters long
                |
                |$diff

--- a/scrooge-generator-tests/src/test/thrift/standalone/test.thrift
+++ b/scrooge-generator-tests/src/test/thrift/standalone/test.thrift
@@ -525,6 +525,12 @@ struct LargeDeltas {
   4000: list<i32> big_numbers
 }
 
+struct TreeNode {
+    1: i32 data,
+    2: list<TreeNode> children,
+    3: optional TreeNode parent
+}
+
 service ReadOnlyService {
   string getName()
 }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/TypeResolver.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/TypeResolver.scala
@@ -202,7 +202,11 @@ case class TypeResolver(
           d.copy(fieldType = resolved),
           withType(sid.name, resolved))
       case s @ Struct(sid, _, fs, _, _) =>
-        val resolved = s.copy(fields = fs.map(apply))
+        // Add the current struct name to the scope to allow self referencing types
+        // TODO: Enforce optional with self referenced field.
+        // For now, we'll depend on the language compiler to error out in those cases.
+        val resolver = withType(sid.name, StructType(s, scopePrefix))
+        val resolved = s.copy(fields = fs.map(resolver.apply))
         ResolvedDefinition(
           resolved,
           withType(sid.name, StructType(resolved, scopePrefix)))


### PR DESCRIPTION
Problem

Scrooge currently doesn't support self-referencing types. This is useful for a number of cases.

Solution

Change the type resolver's scope to include the current type. Add unit tests. Updated gold file and test.thrift to include a self-referencing type. Fixed a bug in GoldFileTest.scala's diff calculation code where if genStr is a prefix of expected, line 108 (getStr(i)) will generate OutOfBoundsException (since the diff is after the genStr string).

Result

Self-referencing types no longer result in TypeNotFoundException. This should resolve https://github.com/twitter/scrooge/issues/243 and partially resolve https://github.com/twitter/scrooge/issues/160. This change doesn't yet support recursive types which is needed to fully resolve https://github.com/twitter/scrooge/issues/160.

This should be a backward compatible change since all the thrift files that are resolved correctly now will continue to get resolved correctly.

One caveat though is that we don't enforce the self-reference type to be optional or collection type. We just depend on the generated language's compiler to enforce that (i.e. we expect that compiler to generate an error if a self-referencing type is specified as required).