### PR TITLE
Output Directory scrooge-maven-plugin

### DIFF
--- a/scrooge-maven-plugin/src/main/java/com/twitter/AbstractMavenScroogeMojo.java
+++ b/scrooge-maven-plugin/src/main/java/com/twitter/AbstractMavenScroogeMojo.java
@@ -145,7 +145,7 @@ abstract class AbstractMavenScroogeMojo extends AbstractMojo {
   private boolean buildExtractedThrift = true;
   
   /**
-   * Whether or not to include ("scrooge") folder in namespace folder, if any
+   * Whether or not to skip creation of scrooge folder in output directory, if need skip
    * @parameter
    * {@code
    * <configuration>

--- a/scrooge-maven-plugin/src/main/java/com/twitter/AbstractMavenScroogeMojo.java
+++ b/scrooge-maven-plugin/src/main/java/com/twitter/AbstractMavenScroogeMojo.java
@@ -143,6 +143,17 @@ abstract class AbstractMavenScroogeMojo extends AbstractMojo {
    * }
    */
   private boolean buildExtractedThrift = true;
+  
+  /**
+   * Whether or not to include ("scrooge") folder in namespace folder, if any
+   * @parameter
+   * {@code
+   * <configuration>
+   *     <includeOutputDirectoryNamespace>false</includeOutputDirectoryNamespace>
+   * </configuration>
+   * }
+   */
+  private boolean includeOutputDirectoryNamespace = true;
 
   /**
    * Whether or not to fix hashcode being default 0
@@ -276,7 +287,7 @@ abstract class AbstractMavenScroogeMojo extends AbstractMojo {
 
           runner.compile(
                   getLog(),
-                  new File(outputDirectory, "scrooge"),
+                  includeOutputDirectoryNamespace ? new File(outputDirectory, "scrooge") : outputDirectory,
                   thriftFiles,
                   includes,
                   thriftNamespaceMap,

--- a/scrooge-maven-plugin/src/test/java/com/twitter/ScroogeMavenPluginTest.java
+++ b/scrooge-maven-plugin/src/test/java/com/twitter/ScroogeMavenPluginTest.java
@@ -57,8 +57,8 @@ public class ScroogeMavenPluginTest extends AbstractMojoTestCase {
     assertNotNull(mojo);
     mojo.execute();
     // Check if both thrift artifacts have scrooge generated classes
-    String[] fileNames =  new String[] {"/scrooge/com/twitter/hello/thriftjava/HelloMessage.java",
-                                        "/scrooge/com/twitter/person/thriftjava/Person.java"};
+    String[] fileNames =  new String[] {"/com/twitter/hello/thriftjava/HelloMessage.java",
+                                        "/com/twitter/person/thriftjava/Person.java"};
     final Collection<String> absExpectFiles = Collections2.transform(
       Arrays.asList(fileNames),
       new Function<String, String>() {

--- a/scrooge-maven-plugin/src/test/resources/unit/project-idl-deps/pom.xml
+++ b/scrooge-maven-plugin/src/test/resources/unit/project-idl-deps/pom.xml
@@ -43,6 +43,7 @@
             <thriftOpt>--finagle</thriftOpt>
           </thriftOpts>
           <language>java</language>
+          <includeOutputDirectoryNamespace>false</includeOutputDirectoryNamespace>
           <resourcesOutputDirectory>${basedir}/target/test/unit/project-idl-deps/target</resourcesOutputDirectory>
           <thriftSourceRoot>${basedir}/target/test/unit/project-idl-deps/src/main/thrift</thriftSourceRoot>
         </configuration>


### PR DESCRIPTION
Skip creation of scrooge folder in output directory in Maven Plugin

Problem

This pull request is in response to issue #217 
The problem is, if **outputDirectory** is **C:\project\test** and the namespace
 in **File.thrift** is **namespace java com.app.thrift** the file output will 
be created in **C:\project\test\scrooge\com\app\thrift\File.java** instead of 
**C:\project\test\com\app\thrift\File.java**.

Solution

Create the property **includeOutputDirectoryNamespace** to enable skip creation
 of scrooge folder in output directory.

Result

When **includeOutputDirectoryNamespace** is not informed, by default, scrooge 
folder will be generated. Instead, if **includeOutputDirectoryNamespace** is 
set to false at pom.xml, the creation of scrooge folder will be skipped