### PR TITLE
Conform to correct Scala function definition syntax

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleService.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleService.scala
@@ -65,7 +65,7 @@ class GoldService$FinagleService(
 
   protected val functionMap = new mutable$HashMap[String, (TProtocol, Int) => Future[Array[Byte]]]()
 
-  protected def addFunction(name: String, f: (TProtocol, Int) => Future[Array[Byte]]) {
+  protected def addFunction(name: String, f: (TProtocol, Int) => Future[Array[Byte]]): Unit = {
     functionMap(name) = f
   }
 

--- a/scrooge-generator/src/main/resources/scalagen/finagleService.scala
+++ b/scrooge-generator/src/main/resources/scalagen/finagleService.scala
@@ -60,7 +60,7 @@ class {{ServiceName}}$FinagleService(
 
   protected val functionMap = new mutable$HashMap[String, (TProtocol, Int) => Future[Array[Byte]]]()
 
-  protected def addFunction(name: String, f: (TProtocol, Int) => Future[Array[Byte]]) {
+  protected def addFunction(name: String, f: (TProtocol, Int) => Future[Array[Byte]]): Unit = {
     functionMap(name) = f
   }
 


### PR DESCRIPTION
Problem

See #246 

Solution

Add `: Unit =` per compiler warning

Result

Compiler warnings should cease

Fixes #246