### PR TITLE
Struct unapply returns Option[TupleN]

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/CollectionId.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/CollectionId.scala
@@ -279,7 +279,7 @@ object CollectionId extends ThriftStructCodec3[CollectionId] {
 
 trait CollectionId
   extends ThriftStruct
-  with scala.Product1[Long]
+  with _root_.scala.Product1[Long]
   with HasThriftStructCodec3[CollectionId]
   with java.io.Serializable
 {

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService.scala
@@ -206,7 +206,7 @@ object GoldService { self =>
         val request: com.twitter.scrooge.test.gold.thriftscala.Request,
         val _passthroughFields: immutable$Map[Short, TFieldBlob])
       extends ThriftStruct
-      with scala.Product1[com.twitter.scrooge.test.gold.thriftscala.Request]
+      with _root_.scala.Product1[com.twitter.scrooge.test.gold.thriftscala.Request]
       with HasThriftStructCodec3[Args]
       with java.io.Serializable
     {
@@ -403,7 +403,7 @@ object GoldService { self =>
           ex
         )
 
-      def unapply(_item: Result): _root_.scala.Option[scala.Product2[Option[com.twitter.scrooge.test.gold.thriftscala.Response], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]] = _root_.scala.Some(_item)
+      def unapply(_item: Result): _root_.scala.Option[_root_.scala.Tuple2[Option[com.twitter.scrooge.test.gold.thriftscala.Response], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]] = _root_.scala.Some(_item.toTuple)
 
 
       @inline private def readSuccessValue(_iprot: TProtocol): com.twitter.scrooge.test.gold.thriftscala.Response = {
@@ -442,7 +442,7 @@ object GoldService { self =>
         val ex: _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException],
         val _passthroughFields: immutable$Map[Short, TFieldBlob])
       extends ThriftResponse[com.twitter.scrooge.test.gold.thriftscala.Response] with ThriftStruct
-      with scala.Product2[Option[com.twitter.scrooge.test.gold.thriftscala.Response], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]
+      with _root_.scala.Product2[Option[com.twitter.scrooge.test.gold.thriftscala.Response], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]
       with HasThriftStructCodec3[Result]
       with java.io.Serializable
     {
@@ -458,6 +458,13 @@ object GoldService { self =>
 
       def _1 = success
       def _2 = ex
+
+      def toTuple: _root_.scala.Tuple2[Option[com.twitter.scrooge.test.gold.thriftscala.Response], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]] = {
+        (
+          success,
+          ex
+        )
+      }
 
       def successField: Option[com.twitter.scrooge.test.gold.thriftscala.Response] = success
       def exceptionFields: Iterable[Option[com.twitter.scrooge.ThriftException]] = Seq(ex)

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/OverCapacityException.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/OverCapacityException.scala
@@ -149,7 +149,7 @@ class OverCapacityException(
     val chillTimeSeconds: Int,
     val _passthroughFields: immutable$Map[Short, TFieldBlob])
   extends ThriftException with com.twitter.finagle.SourcedException with ThriftStruct
-  with scala.Product1[Int]
+  with _root_.scala.Product1[Int]
   with HasThriftStructCodec3[OverCapacityException]
   with java.io.Serializable
 {

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Request.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Request.scala
@@ -409,7 +409,7 @@ object Request extends ThriftStructCodec3[Request] {
       subRequests
     )
 
-  def unapply(_item: Request): _root_.scala.Option[scala.Product5[Seq[String], Set[Int], Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], Seq[com.twitter.scrooge.test.gold.thriftscala.Request]]] = _root_.scala.Some(_item)
+  def unapply(_item: Request): _root_.scala.Option[_root_.scala.Tuple5[Seq[String], Set[Int], Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], Seq[com.twitter.scrooge.test.gold.thriftscala.Request]]] = _root_.scala.Some(_item.toTuple)
 
 
   @inline private def readAListValue(_iprot: TProtocol): Seq[String] = {
@@ -678,7 +678,7 @@ object Request extends ThriftStructCodec3[Request] {
 
 trait Request
   extends ThriftStruct
-  with scala.Product5[Seq[String], Set[Int], Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], Seq[com.twitter.scrooge.test.gold.thriftscala.Request]]
+  with _root_.scala.Product5[Seq[String], Set[Int], Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], Seq[com.twitter.scrooge.test.gold.thriftscala.Request]]
   with HasThriftStructCodec3[Request]
   with java.io.Serializable
 {
@@ -697,6 +697,16 @@ trait Request
   def _3 = aMap
   def _4 = aRequest
   def _5 = subRequests
+
+  def toTuple: _root_.scala.Tuple5[Seq[String], Set[Int], Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], Seq[com.twitter.scrooge.test.gold.thriftscala.Request]] = {
+    (
+      aList,
+      aSet,
+      aMap,
+      aRequest,
+      subRequests
+    )
+  }
 
 
   /**

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Response.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Response.scala
@@ -234,7 +234,7 @@ object Response extends ThriftStructCodec3[Response] {
       responseUnion
     )
 
-  def unapply(_item: Response): _root_.scala.Option[scala.Product2[Int, com.twitter.scrooge.test.gold.thriftscala.ResponseUnion]] = _root_.scala.Some(_item)
+  def unapply(_item: Response): _root_.scala.Option[_root_.scala.Tuple2[Int, com.twitter.scrooge.test.gold.thriftscala.ResponseUnion]] = _root_.scala.Some(_item.toTuple)
 
 
   @inline private def readStatusCodeValue(_iprot: TProtocol): Int = {
@@ -343,7 +343,7 @@ object Response extends ThriftStructCodec3[Response] {
 
 trait Response
   extends ThriftStruct
-  with scala.Product2[Int, com.twitter.scrooge.test.gold.thriftscala.ResponseUnion]
+  with _root_.scala.Product2[Int, com.twitter.scrooge.test.gold.thriftscala.ResponseUnion]
   with HasThriftStructCodec3[Response]
   with java.io.Serializable
 {
@@ -356,6 +356,13 @@ trait Response
 
   def _1 = statusCode
   def _2 = responseUnion
+
+  def toTuple: _root_.scala.Tuple2[Int, com.twitter.scrooge.test.gold.thriftscala.ResponseUnion] = {
+    (
+      statusCode,
+      responseUnion
+    )
+  }
 
 
   /**

--- a/scrooge-generator/src/main/resources/scalagen/struct.scala
+++ b/scrooge-generator/src/main/resources/scalagen/struct.scala
@@ -273,7 +273,7 @@ object {{StructName}} extends ThriftStructCodec3[{{StructName}}] {
   def unapply(_item: {{StructName}}): _root_.scala.Option[{{>optionalType}}] = _root_.scala.Some(_item.{{fieldName}})
 {{/arity1}}
 {{#arityN}}
-  def unapply(_item: {{StructName}}): _root_.scala.Option[{{product}}] = _root_.scala.Some(_item)
+  def unapply(_item: {{StructName}}): _root_.scala.Option[{{tuple}}] = _root_.scala.Some(_item.toTuple)
 {{/arityN}}
 
 
@@ -442,6 +442,16 @@ class {{StructName}}(
   def _{{indexP1}} = {{fieldName}}
 {{/fields}}
 
+{{#arityN}}
+  def toTuple: {{tuple}} = {
+    (
+{{#fields}}
+      {{fieldName}}
+{{/fields|,}}
+    )
+  }
+
+{{/arityN}}
 {{#isResponse}}
   def successField: Option[{{successFieldType}}] = {{successFieldValue}}
   def exceptionFields: Iterable[Option[com.twitter.scrooge.ThriftException]] = {{exceptionValues}}

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
@@ -475,7 +475,7 @@ abstract class TemplateGenerator(val resolvedDoc: ResolvedDocument)
   }
 
   /**
-   * Returns a String "scala.Product${N}[Type1, Type2, ...]" or "scala.Product".
+   * Returns a String "_root_.scala.Product${N}[Type1, Type2, ...]" or "scala.Product".
    */
   def productN(fields: Seq[Field], namespace: Option[Identifier]): String = {
     val arity = fields.length
@@ -483,9 +483,24 @@ abstract class TemplateGenerator(val resolvedDoc: ResolvedDocument)
       val fieldTypes = fields.map { f =>
         genFieldType(f).toData
       }.mkString(", ")
-      s"scala.Product$arity[$fieldTypes]"
+      s"_root_.scala.Product$arity[$fieldTypes]"
     } else {
-      "scala.Product"
+      "_root_.scala.Product"
+    }
+  }
+
+  /**
+   * Returns a String "_root_.scala.Tuple${N}[Type1, Type2, ...]"
+   */
+  def tupleN(fields: Seq[Field], namespace: Option[Identifier]): String = {
+    val arity = fields.length
+    if (arity >= 1 && arity <= 22) {
+      val fieldTypes = fields.map { f =>
+        genFieldType(f).toData
+      }.mkString(", ")
+      s"_root_.scala.Tuple$arity[$fieldTypes]"
+    } else {
+      "_root_.scala.Product"
     }
   }
 }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/StructTemplate.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/StructTemplate.scala
@@ -352,6 +352,7 @@ trait StructTemplate { self: TemplateGenerator =>
       "hasExceptionMessage" -> v(exceptionMsgField.isDefined),
       "exceptionMessageField" -> exceptionMsgField.map(genID).getOrElse { v("")},
       "product" -> v(productN(struct.fields, namespace)),
+      "tuple" -> v(tupleN(struct.fields, namespace)),
       "arity0" -> v(arity == 0),
       "arity1" -> v((if (arity == 1) fieldDictionaries.take(1) else Nil)),
       "arityN" -> v(arity > 1 && arity <= 22),


### PR DESCRIPTION
Problem

Currently, the generated code for thrift structs defines an unapply
method that returns `Option[ProductN]`. This is inconsistent with
Scala's built in behavior when unapply methods are generated for case
classes, which return `Option[TupleN]`. A number of libraries work well
with the latter but not the former (e.g. scala.math.Ordering implicits,
Slick table mappings).

Solution

For consistency with the behavior of Scala case classes, and to improve
library interoperability, this modifies the generated code to return a
tuple rather than product instance. For consistency, the definition of
the ProductN types is also modified to use the `_root_` prefix.

Result

Library interoperability and consistency should be improved; impact on
existing code should be minimal as each TupleN class implements the
corresponding ProductN trait.

I was not sure exactly how best to handle the case where `tupleN` is called for a struct with arity 0 or greater than 22; for now I've just done the same as `productN`; it should never be used, but still doesn't quite feel like the best solution.