### PR TITLE
Allow negative field constants

### DIFF
--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
@@ -302,7 +302,7 @@ class ScalaGeneratorSpec extends JMockSpec with EvalHelper {
       thrift.test.Constants.long_key_long_value_map(2147483648L) must be(2147483648L)
       thrift.test.Constants.long_set.contains(2147483648L) must be(true)
       thrift.test.Constants.long_list.contains(2147483648L) must be(true)
-      thrift.test.Constants.structTestConstant.negativeI32One must be(-39)
+      thrift.test.Constants.structTestConstant.negativeI32FieldOne must be(-39)
       thrift.test.Constants.structTestConstant.fieldTwo must be("two")
       thrift.test.Constants.structTestConstant.fieldThree must be(-986)
     }

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/backend/ScalaGeneratorSpec.scala
@@ -302,6 +302,9 @@ class ScalaGeneratorSpec extends JMockSpec with EvalHelper {
       thrift.test.Constants.long_key_long_value_map(2147483648L) must be(2147483648L)
       thrift.test.Constants.long_set.contains(2147483648L) must be(true)
       thrift.test.Constants.long_list.contains(2147483648L) must be(true)
+      thrift.test.Constants.structTestConstant.negativeI32One must be(-39)
+      thrift.test.Constants.structTestConstant.fieldTwo must be("two")
+      thrift.test.Constants.structTestConstant.fieldThree must be(-986)
     }
 
     "basic structs" should {

--- a/scrooge-generator-tests/src/test/thrift/standalone/const.thrift
+++ b/scrooge-generator-tests/src/test/thrift/standalone/const.thrift
@@ -68,3 +68,14 @@ enum weekDay {
 const weekDay myWfhDay = weekDay.thu;
 const list<weekDay> myDaysOut = [myWfhDay, weekDay.Sat, weekDay.sUN]
 
+struct StuctTest {
+  1: i32 negativeI32One
+  2: string fieldTwo
+  3: i64 fieldThree
+}
+
+const StuctTest structTestConstant = {
+  "negativeI32FieldOne": -39
+  "fieldTwo": "two"
+  "fieldThree": -986
+}

--- a/scrooge-generator-tests/src/test/thrift/standalone/const.thrift
+++ b/scrooge-generator-tests/src/test/thrift/standalone/const.thrift
@@ -69,7 +69,7 @@ const weekDay myWfhDay = weekDay.thu;
 const list<weekDay> myDaysOut = [myWfhDay, weekDay.Sat, weekDay.sUN]
 
 struct StuctTest {
-  1: i32 negativeI32One
+  1: i32 negativeI32FieldOne
   2: string fieldTwo
   3: i64 fieldThree
 }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
@@ -133,7 +133,7 @@ class ScalaGenerator(
     val values = struct.elems
     val fields = values.map { case (f, value) =>
       val v = genConstant(value, Some(f.fieldType))
-      genID(f.sid.toCamelCase) + "=" + (if (f.requiredness.isOptional) "Some(" + v + ")" else v)
+      genID(f.sid.toCamelCase) + " = " + (if (f.requiredness.isOptional) "Some(" + v + ")" else v)
     }
 
     val gid = fieldType match {


### PR DESCRIPTION
For scala generated code, constant structs with negative field values cause compilation error.

For example the generated code:

```
object Constants {
  val FOO: com.example.SomeStruct = com.example.SomeStruct(fieldOne=-1, field2="")
}
```

fails to compile with the error `Connot resolve symbol fieldOne`. The actual problem is that it can not resolve the operator `=-`.

### Expected behavior

It should compile.

### Actual behavior

It does not compile.

### Steps to reproduce the behavior

Create a thrift IDL with a struct and a constant value for that struct.

For example:
```
struct SomeStruct {
  1: i16 fieldOne
  2: string fieldTwo
}

const SomeStuct FOO {
  "fieldOne": -1,
  "fieldTwo": ""
}
```

Solution: put a space after the `=`. Just for good measures, this PR puts one before the `=` also.