### PR TITLE
Revert "scrooge-generator: Handle exceptions thrown in decodeResponse"

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleClient.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleClient.scala
@@ -45,7 +45,7 @@ class GoldService$FinagleClient(
 
   import GoldService._
 
-  protected def encodeRequest(name: String, args: ThriftStruct): ThriftClientRequest = {
+  protected def encodeRequest(name: String, args: ThriftStruct) = {
     val buf = new TMemoryBuffer(512)
     val oprot = protocolFactory.getProtocol(buf)
 
@@ -57,10 +57,7 @@ class GoldService$FinagleClient(
     new ThriftClientRequest(bytes, false)
   }
 
-  protected def decodeResponse[T <: ThriftStruct](
-    resBytes: Array[Byte],
-    codec: ThriftStructCodec[T]
-  ): T = {
+  protected def decodeResponse[T <: ThriftStruct](resBytes: Array[Byte], codec: ThriftStructCodec[T]) = {
     val iprot = protocolFactory.getProtocol(new TMemoryInputTransport(resBytes))
     val msg = iprot.readMessageBegin()
     try {
@@ -113,30 +110,21 @@ class GoldService$FinagleClient(
     val inputArgs = DoGreatThings.Args(request)
     val replyDeserializer: Array[Byte] => _root_.com.twitter.util.Try[com.twitter.scrooge.test.gold.thriftscala.Response] =
       response => {
-        val decodeResult: _root_.com.twitter.util.Try[DoGreatThings.Result] =
-          _root_.com.twitter.util.Try {
-            decodeResponse(response, DoGreatThings.Result)
-          }
+        val result = decodeResponse(response, DoGreatThings.Result)
+        val exception: Throwable =
+        if (false)
+          null // can never happen, but needed to open a block
+        else if (result.ex.isDefined)
+          setServiceName(result.ex.get)
+        else
+          null
 
-        decodeResult match {
-          case t@_root_.com.twitter.util.Throw(_) =>
-            t.cast[com.twitter.scrooge.test.gold.thriftscala.Response]
-          case  _root_.com.twitter.util.Return(result) =>
-            val serviceException: Throwable =
-              if (false)
-                null // can never happen, but needed to open a block
-              else if (result.ex.isDefined)
-                setServiceName(result.ex.get)
-              else
-                null
-
-            if (result.success.isDefined)
-              _root_.com.twitter.util.Return(result.success.get)
-            else if (serviceException != null)
-              _root_.com.twitter.util.Throw(serviceException)
-            else
-              _root_.com.twitter.util.Throw(missingResult("doGreatThings"))
-        }
+        if (result.success.isDefined)
+          _root_.com.twitter.util.Return(result.success.get)
+        else if (exception != null)
+          _root_.com.twitter.util.Throw(exception)
+        else
+          _root_.com.twitter.util.Throw(missingResult("doGreatThings"))
       }
 
     val serdeCtx = new _root_.com.twitter.finagle.thrift.DeserializeCtx[com.twitter.scrooge.test.gold.thriftscala.Response](inputArgs, replyDeserializer)

--- a/scrooge-generator/src/main/resources/scalagen/finagleClient.scala
+++ b/scrooge-generator/src/main/resources/scalagen/finagleClient.scala
@@ -40,7 +40,7 @@ class {{ServiceName}}$FinagleClient(
   import {{ServiceName}}._
 {{^hasParent}}
 
-  protected def encodeRequest(name: String, args: ThriftStruct): ThriftClientRequest = {
+  protected def encodeRequest(name: String, args: ThriftStruct) = {
     val buf = new TMemoryBuffer(512)
     val oprot = protocolFactory.getProtocol(buf)
 
@@ -52,10 +52,7 @@ class {{ServiceName}}$FinagleClient(
     new ThriftClientRequest(bytes, false)
   }
 
-  protected def decodeResponse[T <: ThriftStruct](
-    resBytes: Array[Byte],
-    codec: ThriftStructCodec[T]
-  ): T = {
+  protected def decodeResponse[T <: ThriftStruct](resBytes: Array[Byte], codec: ThriftStructCodec[T]) = {
     val iprot = protocolFactory.getProtocol(new TMemoryInputTransport(resBytes))
     val msg = iprot.readMessageBegin()
     try {

--- a/scrooge-generator/src/main/resources/scalagen/finagleClientFunction.scala
+++ b/scrooge-generator/src/main/resources/scalagen/finagleClientFunction.scala
@@ -10,43 +10,33 @@ private[this] object {{__stats_name}} {
   val inputArgs = {{funcObjectName}}.Args({{argNames}})
   val replyDeserializer: Array[Byte] => _root_.com.twitter.util.Try[{{typeName}}] =
     response => {
-      val decodeResult: _root_.com.twitter.util.Try[{{funcObjectName}}.Result] =
-        _root_.com.twitter.util.Try {
-          decodeResponse(response, {{funcObjectName}}.Result)
-        }
-
-      decodeResult match {
-        case t@_root_.com.twitter.util.Throw(_) =>
-          t.cast[{{typeName}}]
-        case  _root_.com.twitter.util.Return(result) =>
-          val serviceException: Throwable =
+      val result = decodeResponse(response, {{funcObjectName}}.Result)
+      val exception: Throwable =
 {{#hasThrows}}
-            if (false)
-              null // can never happen, but needed to open a block
+      if (false)
+        null // can never happen, but needed to open a block
 {{#throws}}
-            else if (result.{{throwName}}.isDefined)
-              setServiceName(result.{{throwName}}.get)
+      else if (result.{{throwName}}.isDefined)
+        setServiceName(result.{{throwName}}.get)
 {{/throws}}
-            else
-              null
+      else
+        null
 {{/hasThrows}}
 {{^hasThrows}}
-            null
+      null
 {{/hasThrows}}
 
 {{#isVoid}}
-          if (serviceException != null) _root_.com.twitter.util.Throw(serviceException)
-          else _root_.com.twitter.util.Return.Unit
+      if (exception != null) _root_.com.twitter.util.Throw(exception) else Return.Unit
 {{/isVoid}}
 {{^isVoid}}
-          if (result.success.isDefined)
-            _root_.com.twitter.util.Return(result.success.get)
-          else if (serviceException != null)
-            _root_.com.twitter.util.Throw(serviceException)
-          else
-            _root_.com.twitter.util.Throw(missingResult("{{clientFuncNameForWire}}"))
+      if (result.success.isDefined)
+        _root_.com.twitter.util.Return(result.success.get)
+      else if (exception != null)
+        _root_.com.twitter.util.Throw(exception)
+      else
+        _root_.com.twitter.util.Throw(missingResult("{{clientFuncNameForWire}}"))
 {{/isVoid}}
-      }
     }
 
   val serdeCtx = new _root_.com.twitter.finagle.thrift.DeserializeCtx[{{typeName}}](inputArgs, replyDeserializer)


### PR DESCRIPTION
Problem/Solution

Revert changes from RB 796974 while investigating a possible issue.

The RB ID listed is to ensure the internal->external syncing process
starts from the correct SHA.

RB_ID=894819
TBR=true