### PR TITLE
Make Importer configurable in subclasses

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -47,6 +47,13 @@ class Compiler {
   var defaultNamespace: String = CompilerDefaults.defaultNamespace
   var scalaWarnOnJavaNSFallback: Boolean = false
 
+  /**
+   * Customizations may override this method to control
+   * the importer used
+   */
+  protected def getImporter: Importer =
+    Importer(new File(".")) +: Importer(includePaths)
+
   def run() {
     // if --gen-file-map is specified, prepare the map file.
     fileMapWriter = fileMapPath.map { path =>
@@ -61,7 +68,7 @@ class Compiler {
       new FileWriter(file)
     }
 
-    val importer = Importer(new File(".")) +: Importer(includePaths)
+    val importer = getImporter
 
     val isJava = language.equals("java")
     val documentCache = new TrieMap[String, Document]


### PR DESCRIPTION
Problem

While working to improve bazel support, I need to customize the importing to support relative imports (which our builds currently use). Currently we do this by extracting jars and doing modifications on the filesystem, but the jars are in some cases large and this is slow.

I want to customize the Importer, but I have no way to do that except by copy-paste of Compiler locally. If the importer was resolved in a method, I could subclass the Compiler.

Solution

I moved the creation of Importer to a protected method.

