### PR TITLE
Map Enum type to TType.ENUM

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
@@ -192,7 +192,7 @@ class ApacheJavaGenerator(
       case TI32 => "TType.I32"
       case TI64 => "TType.I64"
       case TDouble => "TType.DOUBLE"
-      case EnumType(enumValue, scope) => "TType.I32"
+      case EnumType(enumValue, scope) => "TType.ENUM"
       case StructType(structLike, scope) => "TType.STRUCT"
       case MapType(key, value, cpp) => "TType.MAP"
       case SetType(key, cpp) => "TType.SET"


### PR DESCRIPTION
Problem:

In generaed java thrift bindings, the enum type should map to TType.ENUM
instead of TType.I32.  I am wondering whether this is a bug or done on
purpose.

I found this issue while running the following scenario:

The thrift server is running code generated by a recent Scrooge version,
the client is running with code generated by an older Scrooge version (4.1).

The client calls a thrift method that has an enum argument, the enum type
is serialized and sent over the wire as TTYpe.ENUM.

The Scrooge-generated code on the server side looks like this:

public void read(TProtocol iprot) throws TException {
  TField field;
  iprot.readStructBegin();
  while (true)
  {
    field = iprot.readFieldBegin();
    if (field.type == TType.STOP) {
      break;
  }
  switch (field.id) {
    case 1:
    if (field.type == TType.I32) {    // <-----
      this.myType = MyType.findByValue(iprot.readI32());
    } else {
      TProtocolUtil.skip(iprot, field.type);
    }

The check field.type == TType.I32 is never true since field.type is a
TType.ENUM.

Solution:

Map Enum to the corresponding TType.

However, this change breaks backwards compatibility since the mapping of
enum -> I32 has been released already - in the example above, with this fix,
the client would still send a TType.I32 but the server would now expect a
TType.ENUM.  I guess this would have to be handled in the generated code.
