### PR TITLE
Removes @throws doc from Enum ethod

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/RequestType.scala
@@ -40,7 +40,6 @@ case object RequestType {
 
   /**
    * Find the enum by its integer value, as defined in the Thrift IDL.
-   * @throws NoSuchElementException if the value is not found.
    */
   def apply(value: Int): com.twitter.scrooge.test.gold.thriftscala.RequestType =
     value match {

--- a/scrooge-generator/src/main/resources/scalagen/enum.scala
+++ b/scrooge-generator/src/main/resources/scalagen/enum.scala
@@ -34,7 +34,6 @@ case object {{EnumName}} {
 
   /**
    * Find the enum by its integer value, as defined in the Thrift IDL.
-   * @throws NoSuchElementException if the value is not found.
    */
   def apply(value: Int): {{package}}.{{EnumName}} =
     value match {


### PR DESCRIPTION
Fixes #220 

Problem

Because NoSuchElementException is defined in java.util
which is not automatically imported, scaladoc generation
generates warnings for generated enums. When
projects have fatal-warnings enabled, this fails builds.

Solution

Remove the offending scaladoc line

Result

scaladocs can be generated with fatal-warnings set

