### PR TITLE
Add new option: `--fatal-warnings`

### DIFF
--- a/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/Linter.scala
+++ b/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/Linter.scala
@@ -405,20 +405,33 @@ class Linter(cfg: Config) {
 
     val messages = LintRule.all(rules)(doc)
 
-    messages.foreach {
-      case LintMessage(msg, Error) =>
-        error(s"$inputFile\n$msg")
-      case LintMessage(msg, Warning) =>
-        warning(s"$inputFile\n$msg")
-    }
-
     val errorCount = messages.count(_.level == Error)
     val warnCount = messages.count(_.level == Warning)
 
-    if (errorCount + warnCount > 0 ) {
-      warning("%d warnings and %d errors found".format(messages.size - errorCount, errorCount))
+    if (cfg.fatalWarnings) {
+      val errorAndWarnCount = errorCount + warnCount
+      messages.foreach {
+        case LintMessage(msg, _) =>
+          error(s"$inputFile\n$msg")
+      }
+
+      if (errorAndWarnCount > 0) {
+        warning("%d warnings and %d errors found".format(0, errorAndWarnCount))
+      }
+      errorAndWarnCount
+    } else {
+      messages.foreach {
+        case LintMessage(msg, Error) =>
+          error(s"$inputFile\n$msg")
+        case LintMessage(msg, Warning) =>
+          warning(s"$inputFile\n$msg")
+      }
+
+      if (errorCount + warnCount > 0) {
+        warning("%d warnings and %d errors found".format(warnCount, errorCount))
+      }
+      errorCount
     }
-    errorCount
   }
 
   // Lint cfg.files and return the total number of lint errors found.

--- a/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/Main.scala
+++ b/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/Main.scala
@@ -28,7 +28,8 @@ case class Config(
   ignoreParseErrors: Boolean = false,
   includePaths: Seq[String] = Seq.empty,
   enabledRules: Seq[LintRule] = LintRule.DefaultRules,
-  verbose: Boolean = false
+  verbose: Boolean = false,
+  fatalWarnings: Boolean = false
 )
 
 
@@ -100,6 +101,10 @@ object Main {
 
       opt[Unit]("disable-strict") text ("issue warnings on non-severe parse errors instead of aborting") action { (_, c) =>
         c.copy(strict = false)
+      }
+
+      opt[Unit]("fatal-warnings") text ("convert warnings to errors") action { (_, c) =>
+        c.copy(fatalWarnings = true)
       }
 
       arg[String]("<files...>") unbounded() text ("thrift files to compile") action { (input, c) =>


### PR DESCRIPTION
Problem:

There are many situations that we want to make warnings to errors.
For example, scala compiler has the option that converts warnings to errors (`-Xfatal-warnings`).
However, scrooge-linter has no function to do such a thing.

Solution:

We add a linter option that converts warnings to errors.

Result:

By adding `--fatal-warnings` , we can make warnings to errors.