### PR TITLE
In Java generated code, also read TType.ENUM for enum types.

### DIFF
--- a/scrooge-generator-tests/src/test/resources/apache_output/struct.txt
+++ b/scrooge-generator-tests/src/test/resources/apache_output/struct.txt
@@ -1306,7 +1306,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
           }
           break;
         case 9: // DAY
-          if (field.type == TType.I32) {
+          if (field.type == TType.I32 || field.type == TType.ENUM) {
             this.day = Day.findByValue(iprot.readI32());
           } else { 
             TProtocolUtil.skip(iprot, field.type);

--- a/scrooge-generator-tests/src/test/resources/apache_output/struct_with_hashcode.txt
+++ b/scrooge-generator-tests/src/test/resources/apache_output/struct_with_hashcode.txt
@@ -1374,7 +1374,7 @@ public class Work implements TBase<Work, Work._Fields>, java.io.Serializable, Cl
           }
           break;
         case 9: // DAY
-          if (field.type == TType.I32) {
+          if (field.type == TType.I32 || field.type == TType.ENUM) {
             this.day = Day.findByValue(iprot.readI32());
           } else { 
             TProtocolUtil.skip(iprot, field.type);

--- a/scrooge-generator/src/main/resources/apachejavagen/generate_field_descs.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/generate_field_descs.mustache
@@ -1,3 +1,3 @@
 {{#fields}}
-private static final TField {{#constant_name}}{{name}}{{/constant_name}}_FIELD_DESC = new TField("{{name}}", {{field_type.to_enum}}, (short){{key}});
+private static final TField {{#constant_name}}{{name}}{{/constant_name}}_FIELD_DESC = new TField("{{name}}", {{field_type.to_enum_compat}}, (short){{key}});
 {{/fields}}

--- a/scrooge-generator/src/main/resources/apachejavagen/struct_inner.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/struct_inner.mustache
@@ -344,7 +344,12 @@ this.{{name}} != that.{{name}}
       switch (field.id) {
         {{#fields}}
         case {{key}}: // {{#constant_name}}{{name}}{{/constant_name}}
+          {{#field_type.is_enum}}
+          if (field.type == {{field_type.to_enum}} || field.type == TType.ENUM) {
+          {{/field_type.is_enum}}
+          {{^field_type.is_enum}}
           if (field.type == {{field_type.to_enum}}) {
+          {{/field_type.is_enum}}
             {{#consolidate_newlines}}
             {{{deserialize_field}}}
             {{>generate_isset_set}}

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -19,6 +19,7 @@ package com.twitter.scrooge
 import com.twitter.scrooge.ast.Document
 import com.twitter.scrooge.backend.{GeneratorFactory, ScalaGenerator, ServiceOption}
 import com.twitter.scrooge.frontend.{FileParseException, TypeResolver, ThriftParser, Importer}
+import com.twitter.scrooge.java_generator.ApacheJavaGenerator
 import java.io.{File, FileWriter}
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -47,6 +48,7 @@ class Compiler {
   var language: String = CompilerDefaults.language
   var defaultNamespace: String = CompilerDefaults.defaultNamespace
   var scalaWarnOnJavaNSFallback: Boolean = false
+  var javaSerEnumType: Boolean = false
 
   def run() {
     // if --gen-file-map is specified, prepare the map file.
@@ -89,6 +91,7 @@ class Compiler {
 
         generator match {
           case g: ScalaGenerator => g.warnOnJavaNamespaceFallback = scalaWarnOnJavaNSFallback
+          case g: ApacheJavaGenerator => g.serEnumType = javaSerEnumType
           case _ => ()
         }
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Main.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Main.scala
@@ -116,6 +116,11 @@ object Main {
       }.text("name of language to generate code in (currently supported languages: " +
                  GeneratorFactory.languages.toList.mkString(", ")  + ")")
 
+      opt[Unit]("java-ser-enum-type").action { (_, c) =>
+        compiler.javaSerEnumType = true
+        c
+      }.text("Encode a thrift enum as o.a.t.p.TType.ENUM instead of TType.I32")
+
       opt[String]("experiment-flag").valueName("<flag>").unbounded().action { (flag, c) =>
         c.experimentFlags += flag
         c

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
@@ -27,6 +27,12 @@ class ApacheJavaGenerator(
     val genHashcode: Boolean = true) // Defaulting to true for pants.
   extends Generator(resolvedDoc) {
   val namespaceLanguage = "java"
+
+  // true == serialize the enum type using TType.ENUM, false == use TType.I32
+  // default false for backward compatibility with generated code from older
+  // Scrooge versions (that expect TType.I32 to mean an enum type)
+  var serEnumType: Boolean = false  
+
   var counter = 0
 
   def printConstValue(
@@ -200,6 +206,16 @@ class ApacheJavaGenerator(
       case TBinary => "TType.STRING"
       case _ =>
         throw new ScroogeInternalException("INVALID TYPE IN getTypeString: " + fieldType)
+    }
+  }
+
+  def getTypeStringWithEnumMapping(fieldType: FunctionType): String = {
+    fieldType match {
+      case EnumType(enumValue, scope) => {
+        if (serEnumType) "TType.ENUM"
+        else getTypeString(fieldType)
+      }
+      case _ => getTypeString(fieldType)
     }
   }
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/FieldTypeController.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/FieldTypeController.scala
@@ -6,6 +6,7 @@ import com.twitter.scrooge.frontend.ScroogeInternalException
 
 class FieldTypeController(fieldType: FunctionType, generator: ApacheJavaGenerator) {
   def to_enum = generator.getTypeString(fieldType)
+  def to_enum_compat = generator.getTypeStringWithEnumMapping(fieldType)
   val type_name = generator.typeName(fieldType)
   val type_name_in_container = generator.typeName(fieldType, inContainer = true)
   val type_name_in_container_skip_generic = generator.typeName(fieldType, inContainer = true, skipGeneric = true)


### PR DESCRIPTION
Problem:

The Java generated code currently only reads TType.I32 for enum types.

Solution:

Also read TType.ENUM, matching the behavior of the Scala generated code.
Additionally, send TType.ENUM for enum types instead of TType.I32,
if the flag "java-ser-enum-type" is passed to the compiler.

Also see this related PR that was closed: https://github.com/twitter/scrooge/pull/266

@mosesn FYI