### PR TITLE
Add macro to the list of ScalaKeywords

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/ScalaGenerator.scala
@@ -64,6 +64,7 @@ class ScalaGenerator(
       "implicit",
       "import",
       "lazy",
+      "macro",
       "match",
       "new",
       "null",


### PR DESCRIPTION
The identifier `macro` is now a keyword in Scala. This adds it to the list of `ScalaKeywords` so that it gets escaped properly by Scrooge.