### PR TITLE
Fix module-id whitelisting for SBT 1.0

### DIFF
--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -52,7 +52,8 @@ object ScroogeSBT extends AutoPlugin {
 
   def filter(dependencies: Classpath, whitelist: Set[String]): Classpath = {
     dependencies.filter { dep =>
-      val module = dep.get(AttributeKey[ModuleID]("module-id"))
+      // NOTE: module-id supports SBT pre-1.x while moduleID supports SBT 1.0 and later.
+      val module = dep.get(AttributeKey[ModuleID]("module-id")).orElse(dep.get(AttributeKey[ModuleID]("moduleID")))
       module.exists { m =>
         whitelist.contains(m.name)
       }
@@ -197,7 +198,8 @@ object ScroogeSBT extends AutoPlugin {
 
       val sourceFolder = scroogeThriftExternalSourceFolder.value
       val paths = dependencies.map { dep =>
-        val module = dep.get(AttributeKey[ModuleID]("module-id"))
+        // NOTE: module-id supports SBT pre-1.x while moduleID supports SBT 1.0 and later.
+        val module = dep.get(AttributeKey[ModuleID]("module-id")).orElse(dep.get(AttributeKey[ModuleID]("moduleID")))
         module.flatMap { m =>
           val dest = new File(sourceFolder, m.name)
           IO.createDirectory(dest)


### PR DESCRIPTION
Problem

Previous versions of SBT defined the moduleID with the key "module-id".
This changes in SBT 1.0 to "moduleID" with the change of
`SettingKey[ModuleID]` to `settingKey[ModuleID]` in that key's definition since `settingKey` applies the variable name as the key name via macro.

See https://github.com/sbt/sbt/commit/b27ff9ace7116e43e5978671eab0a8888b7ab16c#diff-46751185767542b1d052bc42435916bd

See #284

Solution

Support both keys via `Option[A] orElse Option[A]`.

Result

Unlikely to cause conflicts that wouldn't have otherwise been caused by a project upgrading to SBT 1.0.
