### PR TITLE
Clarify default for scroogeThriftOutputFolder

### DIFF
--- a/doc/src/sphinx/SBTPlugin.rst
+++ b/doc/src/sphinx/SBTPlugin.rst
@@ -63,7 +63,7 @@ most likely to want to edit:
 - **scroogeThriftOutputFolder: File**
 
   where to put the generated scala files
-  (default: `target/<scala-ver>/src_managed`)
+  (default: `target/<scala-ver>/src_managed/thrift`)
 
 
 Migrating from 3.x.x to 3.18.0

--- a/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
+++ b/scrooge-sbt-plugin/src/main/scala/com/twitter/ScroogeSBT.scala
@@ -123,7 +123,7 @@ object ScroogeSBT extends AutoPlugin {
 
     val scroogeThriftOutputFolder = SettingKey[File](
       "scrooge-thrift-output-folder",
-      "output folder for generated files (defaults to sourceManaged)"
+      "output folder for generated files (defaults to sourceManaged/thrift)"
     )
 
     val scroogeIsDirty = TaskKey[Boolean](


### PR DESCRIPTION
Problem

The explanation for the default value of `scroogeThriftOutputFolder` is out of date. The default output is now `sourceManaged/thrift`.  

The output of `git diff scrooge-4.7.0 -- src/main/scala/com/twitter/ScroogeSBT.scala` shows, in part, this:

```diff
-    scroogeThriftOutputFolder <<= (sourceManaged) { identity },
+    scroogeThriftOutputFolder in Compile := (sourceManaged in Compile).value / "thrift",
+    scroogeThriftOutputFolder in Test := (sourceManaged in Test).value / "thrift",
```
