### PR TITLE
scrooge-sbt-plugin: support sbt 1.1.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -304,11 +304,12 @@ def scroogeSbtPluginSettings = {
 lazy val scroogeSbtPlugin = Project(
   id = "scrooge-sbt-plugin",
   base = file("scrooge-sbt-plugin")
-).enablePlugins(BuildInfoPlugin
+).enablePlugins(
+  BuildInfoPlugin
 ).settings(
   scroogeSbtPluginSettings: _*
 ).settings(
-  scalaVersion := "2.10.6",
+  crossSbtVersions := Vector("0.13.17", "1.1.2"),
   buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
   buildInfoPackage := "com.twitter",
   sbtPlugin := true,


### PR DESCRIPTION
Problem

`scrooge-sbt-plugin` doesn't support for sbt 1.1.x. It seems that there are some people that want to use sbt 1.1.x, so supporting 1.1.x should be needed.

Solution

Enable cross build against 0.13.7 and 1.1.2. Please execute the command like `sbt ";project scrooge-sbt-plugin; ^ publish"`.

Result

We can use scrooge-sbt-plugin against 1.1.x.
