### PR TITLE
[fix] Don't use adapted args when calling Service.apply

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,8 @@ val sharedSettings =
       "-feature", "-Xlint",
       "-encoding", "utf8",
       "-target:jvm-1.8",
-      "-Ypatmat-exhaust-depth", "40"),
+      "-Ypatmat-exhaust-depth", "40",
+      "-Yno-adapted-args"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
     javacOptions in doc := Seq("-source", "1.8")
   )
@@ -128,7 +129,8 @@ val scalacTwoTenOptions = Seq(
   "-deprecation",
   "-unchecked",
   "-feature", "-Xlint",
-  "-encoding", "utf8")
+  "-encoding", "utf8",
+  "-Yno-adapted-args")
 
 // settings for projects that are scala 2.10
 val settingsWithTwoTen =

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleService.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleService.scala
@@ -74,7 +74,7 @@ class GoldService$FinagleService(
       val service = serviceMap.get(msg.name)
       service match {
         case _root_.scala.Some(svc) =>
-          svc(iprot, msg.seqid)
+          svc((iprot, msg.seqid))
         case _ =>
           TProtocolUtil.skip(iprot, TType.STRUCT)
           Future.value(Buf.ByteArray.Owned.extract(

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleService.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService$FinagleService.scala
@@ -98,5 +98,6 @@ class GoldService$FinagleService(
     }
   
     filters.doGreatThings.andThen(methodService)
-  })
+    }
+  )
 }

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/finagle_integration/ScalaIntegrationTest.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/finagle_integration/ScalaIntegrationTest.scala
@@ -38,7 +38,7 @@ class ScalaIntegrationTest extends FunSuite {
     assert(await(muxClient.echo("hello")) == "hello")
     assert(await(muxClient.duplicate("hi")) == "hihi")
     assert(await(muxClient.getDuck(10L)) == "Scrooge")
-    assert(await(muxClient.setDuck(20L, "McDuck")) === ())
+    assert(await(muxClient.setDuck(20L, "McDuck")) === (()))
     await(muxServer.close())
   }
 
@@ -231,7 +231,7 @@ class ScalaIntegrationTest extends FunSuite {
     assert(await(clnt.echo("echo")) == "echo")
     assert(await(clnt.duplicate("y")) == "yy")
     assert(await(clnt.getDuck(3)) == "Scrooge")
-    assert(await(clnt.setDuck(3, "x")) === ())
+    assert(await(clnt.setDuck(3, "x")) === (()))
     assert(await(clnt.triple("x")) == "xxx")
   }
 

--- a/scrooge-generator/src/main/resources/scalagen/finagleService.mustache
+++ b/scrooge-generator/src/main/resources/scalagen/finagleService.mustache
@@ -69,7 +69,7 @@ class {{ServiceName}}$FinagleService(
       val service = serviceMap.get(msg.name)
       service match {
         case _root_.scala.Some(svc) =>
-          svc(iprot, msg.seqid)
+          svc((iprot, msg.seqid))
         case _ =>
           TProtocolUtil.skip(iprot, TType.STRUCT)
           Future.value(Buf.ByteArray.Owned.extract(


### PR DESCRIPTION
This fixes #277

Currently the generated code for FinagleService utilizes adapted args when calling `finagle.Service#apply`. For many people this generates a warning due to `-Ywarn-adapted-args`, and for some (ourselves included) causes the compilation to fail due to `-Yno-adapted-args`

To solve, we explicitly wrap arguments in a 2-tuple

As an aside, and this is a contentious topic, but I think it might be a good idea to add `-Yno-adapted-args` to the build scripts for scrooge, so that issues like this don't crop up in the future. It's a fairly common flag, and it's annoying to have to conditionally disable just for scrooge generated code. Though it will be removed in Scala 3 (scala/scala#6505), so might auto-tupling!