### PR TITLE
Fix string type name in union

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/ResponseUnion.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/ResponseUnion.scala
@@ -112,8 +112,8 @@ object ResponseUnion extends ValidatingThriftStructCodec3[ResponseUnion] {
   val DetailsField: TField = new TField("details", TType.STRING, 2)
   val DetailsFieldManifest: Manifest[Details] = implicitly[Manifest[Details]]
 
-  lazy val structAnnotations: immutable$Map[String, String] =
-    immutable$Map[String, String](
+  lazy val structAnnotations: immutable$Map[java.lang.String, java.lang.String] =
+    immutable$Map[java.lang.String, java.lang.String](
         "u.annotation" -> "y"
     )
 
@@ -161,8 +161,8 @@ object ResponseUnion extends ValidatingThriftStructCodec3[ResponseUnion] {
         manifest[IdAlias],
         IdKeyTypeManifest,
         IdValueTypeManifest,
-        immutable$Map.empty[String, String],
-        immutable$Map.empty[String, String]
+        immutable$Map.empty[java.lang.String, java.lang.String],
+        immutable$Map.empty[java.lang.String, java.lang.String]
       )
   }
 
@@ -202,7 +202,7 @@ object ResponseUnion extends ValidatingThriftStructCodec3[ResponseUnion] {
         manifest[DetailsAlias],
         DetailsKeyTypeManifest,
         DetailsValueTypeManifest,
-        immutable$Map.empty[String, String],
+        immutable$Map.empty[java.lang.String, java.lang.String],
         immutable$Map(
           "u.field.annotation" -> "x"
         )

--- a/scrooge-generator-tests/src/test/thrift/defaults/rhs_structs.thrift
+++ b/scrooge-generator-tests/src/test/thrift/defaults/rhs_structs.thrift
@@ -51,6 +51,7 @@ const list<StructB> ListOfComplexStructs = [
 union SimpleUnion {
   1: i32 a,
   2: string b
+  3: string STRING
 }
 
 const SimpleUnion sss = { "a": 3 }

--- a/scrooge-generator/src/main/resources/scalagen/union.mustache
+++ b/scrooge-generator/src/main/resources/scalagen/union.mustache
@@ -105,16 +105,16 @@ object {{StructName}} extends ValidatingThriftStructCodec3[{{StructName}}] {
   val {{fieldConst}}Manifest: Manifest[{{FieldName}}] = implicitly[Manifest[{{FieldName}}]]
 {{/fields}}
 
-  lazy val structAnnotations: immutable$Map[String, String] =
+  lazy val structAnnotations: immutable$Map[java.lang.String, java.lang.String] =
 {{#structAnnotations}}
-    immutable$Map[String, String](
+    immutable$Map[java.lang.String, java.lang.String](
 {{#pairs}}
         "{{key}}" -> "{{value}}"
 {{/pairs|,}}
     )
 {{/structAnnotations}}
 {{^structAnnotations}}
-    immutable$Map.empty[String, String]
+    immutable$Map.empty[java.lang.String, java.lang.String]
 {{/structAnnotations}}
 
   /**
@@ -169,7 +169,7 @@ object {{StructName}} extends ValidatingThriftStructCodec3[{{StructName}}] {
         ),
 {{/fieldTypeAnnotations}}
 {{^fieldTypeAnnotations}}
-        immutable$Map.empty[String, String],
+        immutable$Map.empty[java.lang.String, java.lang.String],
 {{/fieldTypeAnnotations}}
 {{#fieldFieldAnnotations}}
         immutable$Map(
@@ -179,7 +179,7 @@ object {{StructName}} extends ValidatingThriftStructCodec3[{{StructName}}] {
         )
 {{/fieldFieldAnnotations}}
 {{^fieldFieldAnnotations}}
-        immutable$Map.empty[String, String]
+        immutable$Map.empty[java.lang.String, java.lang.String]
 {{/fieldFieldAnnotations}}
       )
   }


### PR DESCRIPTION
Problem

If a union has a member named STRING, the code generated for it shadows java.lang.String, which leads to compilation errors.

Solution

Use fully qualified name for String type.