### PR TITLE
scrooge-generator: create ThriftMethodStats once

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService.scala
@@ -982,27 +982,25 @@ object GoldService extends _root_.com.twitter.finagle.thrift.GeneratedThriftServ
         }
       }
 
-    private def recordRequest(method: ThriftMethod): Unit = {
-      if (perEndpointStats) {
-        val methodStats = ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name))
-        methodStats.requestsCounter.incr()
+    private def recordRequest(methodStats: Option[ThriftMethodStats]): Unit = {
+      methodStats.foreach { stats =>
+        stats.requestsCounter.incr()
       }
     }
 
-    private def recordResponse(reqRep: ctfs.ReqRep, method: ThriftMethod): Unit = {
+    private def recordResponse(reqRep: ctfs.ReqRep, methodStats: Option[ThriftMethodStats]): Unit = {
       ServerToReqRep.setCtx(reqRep)
-      if (perEndpointStats) {
-        val methodStats = ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name))
+      methodStats.foreach { stats =>
         val responseClass = responseClassifier.applyOrElse(reqRep, ctfs.ResponseClassifier.Default)
         responseClass match {
           case ctfs.ResponseClass.Ignorable => // Do nothing.
           case ctfs.ResponseClass.Successful(_) =>
-            methodStats.successCounter.incr()
+            stats.successCounter.incr()
           case ctfs.ResponseClass.Failed(_) =>
-            methodStats.failuresCounter.incr()
+            stats.failuresCounter.incr()
             reqRep.response match {
               case Throw(ex) =>
-                methodStats.failuresScope.counter(Throwables.mkString(ex): _*).incr()
+                stats.failuresScope.counter(Throwables.mkString(ex): _*).incr()
               case _ =>
             }
         }
@@ -1012,29 +1010,35 @@ object GoldService extends _root_.com.twitter.finagle.thrift.GeneratedThriftServ
     final protected def perMethodStatsFilter(
       method: ThriftMethod
     ): finagle$Filter[(TProtocol, Int), Array[Byte], (TProtocol, Int), RichResponse[method.Args, method.Result]] = {
+      val methodStats = if (perEndpointStats) {
+        Some(ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name)))
+      } else {
+        None
+      }
+
       new finagle$Filter[(TProtocol, Int), Array[Byte], (TProtocol, Int), RichResponse[method.Args, method.Result]] {
         def apply(
           req: (TProtocol, Int),
           service: finagle$Service[(TProtocol, Int), RichResponse[method.Args, method.Result]]
         ): Future[Array[Byte]] = {
-          recordRequest(method)
+          recordRequest(methodStats)
           service(req).transform {
             case Return(value) =>
               value match {
                 case SuccessfulResponse(args, _, result) =>
-                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Return(result.successField.get)), method)
+                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Return(result.successField.get)), methodStats)
                 case ProtocolExceptionResponse(args, _, exp) =>
-                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(exp)), method)
+                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(exp)), methodStats)
                 case ThriftExceptionResponse(args, _, ex) =>
                   val rep = ex match {
                     case exp: ThriftException => setServiceName(exp)
                     case _ => missingResult(serviceName)
                   }
-                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(rep)), method)
+                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(rep)), methodStats)
               }
               Future.value(Buf.ByteArray.Owned.extract(value.response))
             case t @ Throw(_) =>
-              recordResponse(ctfs.ReqRep(req, t), method)
+              recordResponse(ctfs.ReqRep(req, t), methodStats)
               Future.const(t.cast[Array[Byte]])
           }
         }

--- a/scrooge-generator/src/main/resources/scalagen/service.mustache
+++ b/scrooge-generator/src/main/resources/scalagen/service.mustache
@@ -623,6 +623,8 @@ object {{ServiceName}} {{#withFinagle}}extends _root_.com.twitter.finagle.thrift
           stats.counter("failures"),
           stats.scope("failures")
         )
+
+      val nullMethodStats = apply(com.twitter.finagle.stats.NullStatsReceiver)
     }
 
     private case class ThriftMethodStats(
@@ -650,28 +652,24 @@ object {{ServiceName}} {{#withFinagle}}extends _root_.com.twitter.finagle.thrift
         }
       }
 
-    private def recordRequest(methodStats: Option[ThriftMethodStats]): Unit = {
-      methodStats.foreach { stats =>
-        stats.requestsCounter.incr()
-      }
+    private def recordRequest(methodStats: ThriftMethodStats): Unit = {
+      methodStats.requestsCounter.incr()
     }
 
-    private def recordResponse(reqRep: ctfs.ReqRep, methodStats: Option[ThriftMethodStats]): Unit = {
+    private def recordResponse(reqRep: ctfs.ReqRep, methodStats: ThriftMethodStats): Unit = {
       ServerToReqRep.setCtx(reqRep)
-      methodStats.foreach { stats =>
-        val responseClass = responseClassifier.applyOrElse(reqRep, ctfs.ResponseClassifier.Default)
-        responseClass match {
-          case ctfs.ResponseClass.Ignorable => // Do nothing.
-          case ctfs.ResponseClass.Successful(_) =>
-            stats.successCounter.incr()
-          case ctfs.ResponseClass.Failed(_) =>
-            stats.failuresCounter.incr()
-            reqRep.response match {
-              case Throw(ex) =>
-                stats.failuresScope.counter(Throwables.mkString(ex): _*).incr()
-              case _ =>
-            }
-        }
+      val responseClass = responseClassifier.applyOrElse(reqRep, ctfs.ResponseClassifier.Default)
+      responseClass match {
+        case ctfs.ResponseClass.Ignorable => // Do nothing.
+        case ctfs.ResponseClass.Successful(_) =>
+          methodStats.successCounter.incr()
+        case ctfs.ResponseClass.Failed(_) =>
+          methodStats.failuresCounter.incr()
+          reqRep.response match {
+            case Throw(ex) =>
+              methodStats.failuresScope.counter(Throwables.mkString(ex): _*).incr()
+            case _ =>
+          }
       }
     }
 
@@ -679,9 +677,9 @@ object {{ServiceName}} {{#withFinagle}}extends _root_.com.twitter.finagle.thrift
       method: ThriftMethod
     ): finagle$Filter[(TProtocol, Int), Array[Byte], (TProtocol, Int), RichResponse[method.Args, method.Result]] = {
       val methodStats = if (perEndpointStats) {
-        Some(ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name)))
+        ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name))
       } else {
-        None
+        ThriftMethodStats.nullMethodStats
       }
 
       new finagle$Filter[(TProtocol, Int), Array[Byte], (TProtocol, Int), RichResponse[method.Args, method.Result]] {

--- a/scrooge-generator/src/main/resources/scalagen/service.mustache
+++ b/scrooge-generator/src/main/resources/scalagen/service.mustache
@@ -650,27 +650,25 @@ object {{ServiceName}} {{#withFinagle}}extends _root_.com.twitter.finagle.thrift
         }
       }
 
-    private def recordRequest(method: ThriftMethod): Unit = {
-      if (perEndpointStats) {
-        val methodStats = ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name))
-        methodStats.requestsCounter.incr()
+    private def recordRequest(methodStats: Option[ThriftMethodStats]): Unit = {
+      methodStats.foreach { stats =>
+        stats.requestsCounter.incr()
       }
     }
 
-    private def recordResponse(reqRep: ctfs.ReqRep, method: ThriftMethod): Unit = {
+    private def recordResponse(reqRep: ctfs.ReqRep, methodStats: Option[ThriftMethodStats]): Unit = {
       ServerToReqRep.setCtx(reqRep)
-      if (perEndpointStats) {
-        val methodStats = ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name))
+      methodStats.foreach { stats =>
         val responseClass = responseClassifier.applyOrElse(reqRep, ctfs.ResponseClassifier.Default)
         responseClass match {
           case ctfs.ResponseClass.Ignorable => // Do nothing.
           case ctfs.ResponseClass.Successful(_) =>
-            methodStats.successCounter.incr()
+            stats.successCounter.incr()
           case ctfs.ResponseClass.Failed(_) =>
-            methodStats.failuresCounter.incr()
+            stats.failuresCounter.incr()
             reqRep.response match {
               case Throw(ex) =>
-                methodStats.failuresScope.counter(Throwables.mkString(ex): _*).incr()
+                stats.failuresScope.counter(Throwables.mkString(ex): _*).incr()
               case _ =>
             }
         }
@@ -680,29 +678,35 @@ object {{ServiceName}} {{#withFinagle}}extends _root_.com.twitter.finagle.thrift
     final protected def perMethodStatsFilter(
       method: ThriftMethod
     ): finagle$Filter[(TProtocol, Int), Array[Byte], (TProtocol, Int), RichResponse[method.Args, method.Result]] = {
+      val methodStats = if (perEndpointStats) {
+        Some(ThriftMethodStats((if (serviceName != "") stats.scope(serviceName) else stats).scope(method.name)))
+      } else {
+        None
+      }
+
       new finagle$Filter[(TProtocol, Int), Array[Byte], (TProtocol, Int), RichResponse[method.Args, method.Result]] {
         def apply(
           req: (TProtocol, Int),
           service: finagle$Service[(TProtocol, Int), RichResponse[method.Args, method.Result]]
         ): Future[Array[Byte]] = {
-          recordRequest(method)
+          recordRequest(methodStats)
           service(req).transform {
             case Return(value) =>
               value match {
                 case SuccessfulResponse(args, _, result) =>
-                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Return(result.successField.get)), method)
+                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Return(result.successField.get)), methodStats)
                 case ProtocolExceptionResponse(args, _, exp) =>
-                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(exp)), method)
+                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(exp)), methodStats)
                 case ThriftExceptionResponse(args, _, ex) =>
                   val rep = ex match {
                     case exp: ThriftException => setServiceName(exp)
                     case _ => missingResult(serviceName)
                   }
-                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(rep)), method)
+                  recordResponse(ctfs.ReqRep(args, _root_.com.twitter.util.Throw(rep)), methodStats)
               }
               Future.value(Buf.ByteArray.Owned.extract(value.response))
             case t @ Throw(_) =>
-              recordResponse(ctfs.ReqRep(req, t), method)
+              recordResponse(ctfs.ReqRep(req, t), methodStats)
               Future.const(t.cast[Array[Byte]])
           }
         }


### PR DESCRIPTION
Problem

The current implementation of per endpoint stats creates a newly scoped
stats receiver and instance of ThriftMethodStats on each request; it
consequently also creates counters for requests/success/failures on each
request. For some StatsReceivers, this may be expensive, or at least,
not trivial.

Solution

This moves the creation of ThriftMethodStats into perMethodStatsFilter,
where a single instance is (optionally) created for the filter, and then
passed into updated recordRequest/recordResponse methods.

In addition to being more efficient, this also deduplicates code a
little bit.

It's worth noting that when perEndpointStats is false, it appears that
both recordRequest and recordResponse are no-ops; I considered
reorganizing the code to only call them if perEndpointStats is true
(e.g. methodStats.foreach(recordRequest) rather than
 recordRequest(methodStats)) but opted to keep the scope of the change
smaller for now.