### PR TITLE
scrooge: update sbt 0.13.x version and add jdk11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ notifications:
 
 before_script:
   - unset SBT_OPTS # default $SBT_OPTS is irrelevant to sbt launcher
-  - curl -s https://raw.githubusercontent.com/twitter/dodo/develop/bin/build | bash -s -- --no-test --scala-version $TRAVIS_SCALA_VERSION scrooge
+  - curl -s https://raw.githubusercontent.com/twitter/dodo/enbnt/jdk11-support/bin/build | bash -s -- --no-test --scala-version $TRAVIS_SCALA_VERSION scrooge
 
 script:
   - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ scala:
 
 jdk:
   - openjdk8
+  - openjdk11
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,15 @@ git:
 env:
   - JAVA_OPTS="-Dsbt.log.noformat=true"
 
+cache: false
+
 # These directories are cached to S3 at the end of the build
-cache:
-  directories:
-   - $HOME/.ivy2/cache
-   - $HOME/.ivy2/local/com.twitter
-   - $HOME/.sbt
-   - $HOME/.dodo
+# cache:
+#   directories:
+#    - $HOME/.ivy2/cache
+#    - $HOME/.ivy2/local/com.twitter
+#    - $HOME/.sbt
+#    - $HOME/.dodo
 
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates

--- a/build.sbt
+++ b/build.sbt
@@ -181,35 +181,6 @@ val sharedSettings =
     javacOptions in doc := Seq("-source", "1.8")
   )
 
-// scalac options for projects that are scala 2.10
-// or cross compiled with scala 2.10
-val scalacTwoTenOptions = Seq(
-  "-deprecation",
-  "-unchecked",
-  "-feature", "-Xlint",
-  "-encoding", "utf8")
-
-// settings for projects that are scala 2.10
-val settingsWithTwoTen =
-  sharedSettingsWithoutScalaVersion ++
-  Seq(
-    scalaVersion := "2.12.8",
-    scalacOptions := scalacTwoTenOptions,
-    javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
-    javacOptions in doc := Seq("-source", "1.8")
-  )
-
-// settings for projects that are cross compiled with scala 2.10
-val settingsCrossCompiledWithTwoTen =
-  sharedSettingsWithoutScalaVersion ++
-  Seq(
-    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
-    scalaVersion := "2.12.8",
-    scalacOptions := scalacTwoTenOptions,
-    javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
-    javacOptions in doc := Seq("-source", "1.8")
-  )
-
 val jmockSettings = Seq(
   libraryDependencies ++= Seq(
     "org.jmock" % "jmock" % "2.9.0" % "test",
@@ -253,13 +224,11 @@ lazy val scroogePublishLocal = Project(
   sharedSettings
 ).aggregate(publishedProjects: _*)
 
-// must be cross compiled with scala 2.10 because scrooge-sbt-plugin
-// has a dependency on this.
 lazy val scroogeGenerator = Project(
   id = "scrooge-generator",
   base = file("scrooge-generator")
 ).settings(
-  settingsCrossCompiledWithTwoTen
+  sharedSettings
 ).settings(
   name := "scrooge-generator",
   libraryDependencies ++= Seq(
@@ -353,7 +322,7 @@ lazy val scroogeAdaptive = Project(
 // already sets it, and setting it again breaks the plugin.
 def scroogeSbtPluginSettings = {
   if (!releaseVersion.trim.endsWith("SNAPSHOT")) {
-    settingsWithTwoTen
+    sharedSettings
       .filter(_.key.key.label != "publishTo") ++
       Seq(
         bintrayRepository := "sbt-plugins",
@@ -361,7 +330,7 @@ def scroogeSbtPluginSettings = {
         publishMavenStyle := false
       )
   } else {
-    settingsWithTwoTen
+    sharedSettings
   }
 }
 lazy val scroogeSbtPlugin = Project(

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,15 @@ val adaptiveScroogeTestThriftSettings = Seq(
 )
 
 def gcJavaOptions: Seq[String] = {
+  val javaVersion = System.getProperty("java.version")
+  if(javaVersion.startsWith("1.8")) {
+    jdk8GcJavaOptions
+  } else {
+    jdk11GcJavaOptions
+  }
+}
+
+def jdk8GcJavaOptions: Seq[String] = {
   Seq(
     "-XX:+UseParNewGC",
     "-XX:+UseConcMarkSweepGC",
@@ -56,6 +65,12 @@ def gcJavaOptions: Seq[String] = {
     "-Xms512M",
     "-Xmx2G"
   )
+}
+
+def jdk11GcJavaOptions: Seq[String] = {
+  Seq(
+    "-XX:+UseConcMarkSweepGC"
+  ) ++ jdk8GcJavaOptions
 }
 
 def travisTestJavaOptions: Seq[String] = {
@@ -178,7 +193,7 @@ val scalacTwoTenOptions = Seq(
 val settingsWithTwoTen =
   sharedSettingsWithoutScalaVersion ++
   Seq(
-    scalaVersion := "2.10.7",
+    scalaVersion := "2.12.8",
     scalacOptions := scalacTwoTenOptions,
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
     javacOptions in doc := Seq("-source", "1.8")
@@ -188,7 +203,7 @@ val settingsWithTwoTen =
 val settingsCrossCompiledWithTwoTen =
   sharedSettingsWithoutScalaVersion ++
   Seq(
-    crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
+    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
     scalaVersion := "2.12.8",
     scalacOptions := scalacTwoTenOptions,
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
@@ -356,8 +371,8 @@ lazy val scroogeSbtPlugin = Project(
 ).settings(
   scroogeSbtPluginSettings: _*
 ).settings(
-  scalaVersion := "2.10.7",
-  crossSbtVersions := Seq("0.13.18", "1.2.8"),
+  scalaVersion := "2.12.8",
+  crossSbtVersions := Seq("1.2.8"),
   buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
   buildInfoPackage := "com.twitter",
   sbtPlugin := true,

--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,7 @@ val scalacTwoTenOptions = Seq(
 val settingsWithTwoTen =
   sharedSettingsWithoutScalaVersion ++
   Seq(
-    scalaVersion := "2.10.6",
+    scalaVersion := "2.10.7",
     scalacOptions := scalacTwoTenOptions,
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7", "-Xlint:unchecked"),
     javacOptions in doc := Seq("-source", "1.7")
@@ -188,7 +188,7 @@ val settingsWithTwoTen =
 val settingsCrossCompiledWithTwoTen =
   sharedSettingsWithoutScalaVersion ++
   Seq(
-    crossScalaVersions := Seq("2.10.6", "2.11.12", "2.12.8", "2.13.0"),
+    crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
     scalaVersion := "2.12.8",
     scalacOptions := scalacTwoTenOptions,
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7", "-Xlint:unchecked"),
@@ -356,7 +356,7 @@ lazy val scroogeSbtPlugin = Project(
 ).settings(
   scroogeSbtPluginSettings: _*
 ).settings(
-  scalaVersion := "2.10.6",
+  scalaVersion := "2.10.7",
   crossSbtVersions := Seq("0.13.18", "1.2.8"),
   buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
   buildInfoPackage := "com.twitter",

--- a/build.sbt
+++ b/build.sbt
@@ -180,8 +180,8 @@ val settingsWithTwoTen =
   Seq(
     scalaVersion := "2.10.7",
     scalacOptions := scalacTwoTenOptions,
-    javacOptions ++= Seq("-source", "1.7", "-target", "1.7", "-Xlint:unchecked"),
-    javacOptions in doc := Seq("-source", "1.7")
+    javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
+    javacOptions in doc := Seq("-source", "1.8")
   )
 
 // settings for projects that are cross compiled with scala 2.10
@@ -191,8 +191,8 @@ val settingsCrossCompiledWithTwoTen =
     crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
     scalaVersion := "2.12.8",
     scalacOptions := scalacTwoTenOptions,
-    javacOptions ++= Seq("-source", "1.7", "-target", "1.7", "-Xlint:unchecked"),
-    javacOptions in doc := Seq("-source", "1.7")
+    javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
+    javacOptions in doc := Seq("-source", "1.8")
   )
 
 val jmockSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -357,7 +357,7 @@ lazy val scroogeSbtPlugin = Project(
   scroogeSbtPluginSettings: _*
 ).settings(
   scalaVersion := "2.10.6",
-  crossSbtVersions := Seq("0.13.16", "1.2.8"),
+  crossSbtVersions := Seq("0.13.18", "1.2.8"),
   buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
   buildInfoPackage := "com.twitter",
   sbtPlugin := true,


### PR DESCRIPTION
Problem

Scrooge currently uses sbt 0.13.16 for cross-build support on Scala 2.10,
which is not compatible with JDK 11.

Solution

Move sbt to 0.13.18 (latest) and update travis-ci config to use JDK 11.
