### PR TITLE
scrooge-linter: warn when function names are reserved words

### DIFF
--- a/doc/src/sphinx/Linter.rst
+++ b/doc/src/sphinx/Linter.rst
@@ -10,9 +10,9 @@ To run the thrift linter with sbt:
 
 .. code-block:: bash
 
-    $ ./sbt 'scrooge-linter/run-main com.twitter.scrooge.linter.Main --help'
+    $ ./sbt 'scrooge-linter/runMain com.twitter.scrooge.linter.Main --help'
 
-    $ ./sbt 'scrooge-linter/run-main com.twitter.scrooge.linter.Main /path/to/thrift/file.thrift'
+    $ ./sbt 'scrooge-linter/runMain com.twitter.scrooge.linter.Main /path/to/thrift/file.thrift'
 
 List of rules
 -------------
@@ -35,4 +35,4 @@ The warning-level rules are:
 
    Field names must be lowerCamelCase.
 
-2. Struct and field names must not be keywords in Scala, Java, Ruby, Python, PHP.
+2. Struct, field, and function names must not be keywords in Scala, Java, Ruby, Python, PHP, Javascript, and Go

--- a/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/LintRule.scala
+++ b/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/LintRule.scala
@@ -252,7 +252,7 @@ object LintRule {
   }
 
   object Keywords extends LintRule {
-    // Struct and field names should not be keywords in Scala, Java, Ruby, Python, PHP.
+    // Struct, field, and function names should not be keywords in Scala, Java, Ruby, Python, PHP, Javascript, and Go.
     def apply(doc: Document): Seq[LintMessage] = {
       val messages = new ArrayBuffer[LintMessage]
       doc.defs.collect {
@@ -276,6 +276,18 @@ object LintRule {
           } messages += LintMessage(
             s"Found field names that are $lang keywords: ${fieldNames.mkString(", ")}. " +
               s"Avoid using keywords as identifiers.\n${fields.head.pos.longString}"
+          )
+
+        case service: Service =>
+          for {
+            (lang, keywords) <- languageKeywords
+            functions = service.functions.filter { f =>
+              keywords.contains(f.originalName)
+            } if functions.nonEmpty
+            functionNames = functions.map(_.originalName)
+          } messages += LintMessage(
+            s"Found function names that are $lang keywords: ${functionNames.mkString(", ")}. " +
+              s"Avoid using keywords as identifiers.\n"
           )
       }
       messages.toSeq
@@ -520,6 +532,78 @@ object LintRule {
         "while",
         "with",
         "yield"
+      ),
+      "javascript" -> Set(
+        "await",
+        "break",
+        "case",
+        "catch",
+        "class",
+        "const",
+        "continue",
+        "debugger",
+        "default",
+        "delete",
+        "do",
+        "else",
+        "enum",
+        "export",
+        "extends",
+        "finally",
+        "for",
+        "function",
+        "if",
+        "implements",
+        "import",
+        "in",
+        "instanceof",
+        "interface",
+        "let",
+        "new",
+        "package",
+        "private",
+        "protected",
+        "public",
+        "return",
+        "static",
+        "super",
+        "switch",
+        "this",
+        "throw",
+        "try",
+        "typeof",
+        "var",
+        "void",
+        "while",
+        "with",
+        "yield"
+      ),
+      "go" -> Set(
+        "break",
+        "case",
+        "chan",
+        "const",
+        "continue",
+        "default",
+        "defer",
+        "else",
+        "fallthrough",
+        "for",
+        "func",
+        "go",
+        "goto",
+        "if",
+        "import",
+        "interface",
+        "map",
+        "package",
+        "range",
+        "return",
+        "select",
+        "struct",
+        "switch",
+        "type",
+        "var"
       )
     )
   }

--- a/scrooge-linter/src/test/scala/com/twitter/scrooge/linter/LinterSpec.scala
+++ b/scrooge-linter/src/test/scala/com/twitter/scrooge/linter/LinterSpec.scala
@@ -354,6 +354,35 @@ class LinterSpec extends WordSpec with MustMatchers {
       assert(errors(0).msg contains ("Avoid using keywords"))
     }
 
+    "fail Keywords if keyword used as function name" in {
+      val errors = LintRule
+        .Keywords(
+          Document(
+            Seq(),
+            Seq(
+              Service(
+                SimpleID("SomeService"),
+                None,
+                Seq(
+                  Function(
+                    SimpleID("delete"), // delete is a keyword in javascript
+                    "delete",
+                    TString,
+                    genFields(2),
+                    throws = Seq(),
+                    docstring = None
+                  )
+                ),
+                None
+              )
+            )
+          )
+        )
+        .toSeq
+      errors.length must be(1)
+      assert(errors(0).msg contains ("Avoid using keywords"))
+    }
+
     "pass non negative index" in {
       mustPass(
         LintRule.FieldIndexGreaterThanZeroRule(


### PR DESCRIPTION
Problem

The Apache Thrift compiler will fail to compile if it encounters struct, field, or function names that contain reserved words from various programming languages. However, Scrooge will compile these files successfully. This can cause problems when one developer creates a service using Scrooge, and another developer tries to create a client for this service using Apache Thrift.

Solution

- Expanded the linter "Keywords" rule to include function names in addition to Struct and field names
- Added Javascript and Go keywords to the lists of keywords to warn on.

Result

Users will get a warning from the linter if they attempt to use a keyword as a function name.
Users will get a warning from the linter if they attempt to use a Javascript or Go keyword as a struct, field, or function name.

Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

Describe the modifications you've done.

Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.
