### PR TITLE
Various fixes for scrooge-generator

### DIFF
--- a/scrooge-generator/src/main/resources/androidgen/generate_deserialize_field.mustache
+++ b/scrooge-generator/src/main/resources/androidgen/generate_deserialize_field.mustache
@@ -40,6 +40,6 @@ iprot.read{{field_type.get_type}}End();
 {{/field_type.is_base_type_or_binary}}
 
 {{#field_type.is_enum}}
-{{name}} = {{{field_type.type_name_in_container}}}.findByValue(iprot.readI32());
+{{name}} = {{{field_type.qualified_type_name}}}.findByValue(iprot.readI32());
 {{/field_type.is_enum}}
 {{/consolidate_newlines}}

--- a/scrooge-generator/src/main/resources/apachejavagen/generate_deserialize_field.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/generate_deserialize_field.mustache
@@ -49,6 +49,6 @@ iprot.read{{field_type.get_type}}End();
 {{/field_type.is_base_type_or_binary}}
 
 {{#field_type.is_enum}}
-{{name}} = {{{field_type.type_name_in_container}}}.findByValue(iprot.readI32());
+{{name}} = {{{field_type.qualified_type_name}}}.findByValue(iprot.readI32());
 {{/field_type.is_enum}}
 {{/consolidate_newlines}}

--- a/scrooge-generator/src/main/resources/apachejavagen/generate_java_enum_value_annotations.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/generate_java_enum_value_annotations.mustache
@@ -10,7 +10,7 @@ static {
     {
       Map<String, String> tmpFieldMap = new HashMap<String, String>();
       {{#value.annotations}}
-      tmpFieldMap.put("{{key}}", "{{value}}");
+      tmpFieldMap.put("{{key}}", "{{{value}}}");
       {{/value.annotations}}
       tmpMap.put({{value.name}}, Collections.unmodifiableMap(tmpFieldMap));
     }

--- a/scrooge-generator/src/main/resources/apachejavagen/generate_java_field_annotations.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/generate_java_field_annotations.mustache
@@ -10,7 +10,7 @@ static {
     {
       Map<String, String> tmpFieldMap = new HashMap<String, String>();
       {{#value}}
-      tmpFieldMap.put("{{key}}", "{{value}}");
+      tmpFieldMap.put("{{key}}", "{{{value}}}");
       {{/value}}
       tmpMap.put(_Fields.{{#constant_name}}{{key.originalName}}{{/constant_name}}, Collections.unmodifiableMap(tmpFieldMap));
     }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Header.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Header.scala
@@ -21,7 +21,7 @@ case class Include(filePath: String, document: Document) extends Header {
    * Then we can use type Bar like this:
    *    foo.Bar
    */
-  val prefix: SimpleID = SimpleID(filePath.split('/').last.split('.').head)
+  val prefix: Identifier = Identifier(filePath.split('/').last.split('.').dropRight(1).mkString("."))
 }
 
 case class CppInclude(file: String) extends Header

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Type.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/AST/Type.scala
@@ -25,15 +25,15 @@ sealed trait NamedType extends FieldType {
   def sid: SimpleID
 
   /** Filename of the containing file if the type is included from another file */
-  def scopePrefix: Option[SimpleID]
+  def scopePrefix: Option[Identifier]
 }
 
-case class StructType(struct: StructLike, scopePrefix: Option[SimpleID] = None) extends NamedType {
+case class StructType(struct: StructLike, scopePrefix: Option[Identifier] = None) extends NamedType {
   val sid: SimpleID = struct.sid
   override def toString: String = "Struct(?)"
 }
 
-case class EnumType(enum: Enum, scopePrefix: Option[SimpleID] = None) extends NamedType {
+case class EnumType(enum: Enum, scopePrefix: Option[Identifier] = None) extends NamedType {
   val sid: SimpleID = enum.sid
   override def toString: String = "Enum(?)"
 }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/CocoaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/CocoaGenerator.scala
@@ -262,7 +262,7 @@ class CocoaGenerator(
 
   override def qualifyNamedType(t: NamedType, namespace: Option[Identifier] = None): Identifier =
     t.scopePrefix match {
-      case Some(scope) => t.sid.prepend(getIncludeNamespace(scope.name).fullName)
+      case Some(scope) => t.sid.prepend(getIncludeNamespace(scope.fullName).fullName)
       case None => t.sid.prepend(currentNamespace)
     }
 

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/Generator.scala
@@ -386,7 +386,7 @@ abstract class TemplateGenerator(val resolvedDoc: ResolvedDocument)
    */
   def qualifyNamedType(t: NamedType, namespace: Option[Identifier] = None): Identifier =
     t.scopePrefix match {
-      case Some(scope) => t.sid.addScope(getIncludeNamespace(scope.name))
+      case Some(scope) => t.sid.addScope(getIncludeNamespace(scope.fullName))
       case None if namespace.isDefined => t.sid.addScope(namespace.get)
       case None => t.sid
     }

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/java_generator/ApacheJavaGenerator.scala
@@ -150,12 +150,12 @@ class ApacheJavaGenerator(
    */
   def qualifyNamedType(
     sid: SimpleID,
-    scopePrefixOption: Option[SimpleID],
+    scopePrefixOption: Option[Identifier],
     fileNamespaceOption: Option[Identifier] = None
   ): Identifier = {
     scopePrefixOption
       .map { scopePrefix =>
-        sid.addScope(getIncludeNamespace(scopePrefix.name))
+        sid.addScope(getIncludeNamespace(scopePrefix.fullName))
       }.orElse {
         fileNamespaceOption.map { fileNamespace =>
           sid.addScope(fileNamespace)

--- a/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/LintRule.scala
+++ b/scrooge-linter/src/main/scala/com/twitter/scrooge/linter/LintRule.scala
@@ -54,10 +54,10 @@ object LintRule {
 
       def findUnpersistedStructs(
         s: StructLike,
-        scopePrefix: Option[SimpleID] = None
+        scopePrefix: Option[Identifier] = None
       ): Seq[String] = {
         val current =
-          if (!isPersisted(s)) Seq(scopePrefix.map(_.name + ".").getOrElse("") + s.sid.name)
+          if (!isPersisted(s)) Seq(scopePrefix.map(_.fullName + ".").getOrElse("") + s.sid.name)
           else Seq.empty
         (current ++ findUnpersistedStructsFromFields(s.fields.map(_.fieldType))).distinct
       }


### PR DESCRIPTION
# Problems

1. Enumeration class name conflicts with class members.

Consider the following IDL:

```thrift
enum OrganizationType {
    TYPE_A = 1
    TYPE_B = 2
}

struct Organization {
    1: OrganizationType OrganizationType
}
```

This will be converted to something like:

```java
{
    TList _list430 = iprot.readListBegin();
    this.OrganizationType = new ArrayList<OrganizationType>(_list430.size);
    for (int _i431 = 0; _i431 < _list430.size; ++_i431)
    {
        OrganizationType _elem432;
        _elem432 = OrganizationType.findByValue(iprot.readI32());
        //         ^--------------- this conflicts with the field name
        this.OrganizationType.add(_elem432);
    }
    iprot.readListEnd();
}
```

Which cannot compile.

2. Scrooge generates invalid string escape sequences when the field annotation contains certain characters.

For example:

```thrift
struct Foo {
    1: i32 bar (tag1 = "\"value\"")
}
```

This will be converted to something like:

```java
{
    Map<String, String> tmpFieldMap = new HashMap<String, String>();
    tmpFieldMap.put("tag1", "\&quote;value\&quote;");
    //                       ^------- invalid escape sequences
    tmpMap.put(_Fields.TENANT_ID, Collections.unmodifiableMap(tmpFieldMap));
}
```

3. Currently scrooge-generator does not support more than one dot in thrift file name.

This might be related to issue #44 , but since it's been 7 years, I decided to fix it myself.

Suppose we have a thrift file with the name `com.whatever.product.module1.thrift`:

```thrift
struct Foo {
    1: i32 foo_field;
}
```

... and another thrift file that includes `com.whatever.product.module1.thrift`: 

```thrift
include "com.whatever.product.module1.thrift"
struct Bar {
    1: com.whatever.product.module1.Foo bar_field;
}
```

This doesn't work with the current version of scrooge-generator.

# Solutions

1. By replacing the type name with a fully-qualified one solves the problem.
2. Mustache will html-escape everything that is wrapped by `{{...}}`. By replacing the `{{value}}` with `{{{value}}}` solves the problem.
3. I found in the code what appears to be assuming the base part of a file name to be a `SimpleID`, which in fact isn't the case. Changing the `scopePrefix` to `Identifier` & other related places fixes this problem.