### PR TITLE
fix: use fully-qualified class name for calling enum's "findByValue"

### DIFF
--- a/scrooge-generator-tests/src/test/resources/test_thrift/struct_field_with_same_name_and_type.thrift
+++ b/scrooge-generator-tests/src/test/resources/test_thrift/struct_field_with_same_name_and_type.thrift
@@ -1,0 +1,10 @@
+namespace java test_enum
+
+enum OrganizationType {
+    TYPE_A = 1
+    TYPE_B = 2
+}
+
+struct Organization {
+    1: OrganizationType OrganizationType
+}

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
@@ -256,7 +256,6 @@ class ApacheJavaGeneratorSpec extends Spec {
         result must be(List("No fields set for union type 'DeepValidationUnion'."))
       }
     }
-  }
 
   "passthrough fields" should {
     "passthroughStruct" in {
@@ -330,4 +329,11 @@ class ApacheJavaGeneratorSpec extends Spec {
 
   }
 
+    "generate enum with fully-qualified class name" in {
+      val doc = generateDoc(getFileContents("test_thrift/struct_field_with_same_name_and_type.thrift"))
+      val gen = getGenerator(doc)
+      val ctrl = new StructController(doc.structs(0), Set(), false, gen, doc.namespace("java"))
+      gen.renderMustache("struct.mustache", ctrl).trim must include ("test_enum.OrganizationType.findByValue(iprot.readI32())")
+    }
+  }
 }

--- a/scrooge-generator/src/main/resources/androidgen/generate_deserialize_field.mustache
+++ b/scrooge-generator/src/main/resources/androidgen/generate_deserialize_field.mustache
@@ -40,6 +40,6 @@ iprot.read{{field_type.get_type}}End();
 {{/field_type.is_base_type_or_binary}}
 
 {{#field_type.is_enum}}
-{{name}} = {{{field_type.type_name_in_container}}}.findByValue(iprot.readI32());
+{{name}} = {{{field_type.qualified_type_name}}}.findByValue(iprot.readI32());
 {{/field_type.is_enum}}
 {{/consolidate_newlines}}

--- a/scrooge-generator/src/main/resources/apachejavagen/generate_deserialize_field.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/generate_deserialize_field.mustache
@@ -49,6 +49,6 @@ iprot.read{{field_type.get_type}}End();
 {{/field_type.is_base_type_or_binary}}
 
 {{#field_type.is_enum}}
-{{name}} = {{{field_type.type_name_in_container}}}.findByValue(iprot.readI32());
+{{name}} = {{{field_type.qualified_type_name}}}.findByValue(iprot.readI32());
 {{/field_type.is_enum}}
 {{/consolidate_newlines}}


### PR DESCRIPTION
# Problem

Enumeration class name conflicts with class members.

Consider the following IDL:

```thrift
enum OrganizationType {
    TYPE_A = 1
    TYPE_B = 2
}

struct Organization {
    1: OrganizationType OrganizationType
}
```

This will be converted to something like:

```java
{
    TList _list430 = iprot.readListBegin();
    this.OrganizationType = new ArrayList<OrganizationType>(_list430.size);
    for (int _i431 = 0; _i431 < _list430.size; ++_i431)
    {
        OrganizationType _elem432;
        _elem432 = OrganizationType.findByValue(iprot.readI32());
        //         ^--------------- this conflicts with the field name
        this.OrganizationType.add(_elem432);
    }
    iprot.readListEnd();
}
```

Which does not compile.

# Solution

By replacing the type name with a fully-qualified one solves the problem.
