### PR TITLE
fix: invalid string escape in annotations

### DIFF
--- a/scrooge-generator-tests/src/test/resources/test_thrift/annotations.thrift
+++ b/scrooge-generator-tests/src/test/resources/test_thrift/annotations.thrift
@@ -1,0 +1,5 @@
+namespace java test.annotations
+
+struct FooStruct {
+    1: i32 field (tag1 = "\"value\"")
+}

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/java_generator/ApacheJavaGeneratorSpec.scala
@@ -256,7 +256,6 @@ class ApacheJavaGeneratorSpec extends Spec {
         result must be(List("No fields set for union type 'DeepValidationUnion'."))
       }
     }
-  }
 
   "passthrough fields" should {
     "passthroughStruct" in {
@@ -330,4 +329,11 @@ class ApacheJavaGeneratorSpec extends Spec {
 
   }
 
+    "generate correctly escaped field annotation" in {
+      val doc = generateDoc(getFileContents("test_thrift/annotations.thrift"))
+      val gen = getGenerator(doc)
+      val ctrl = new StructController(doc.structs(0), Set(), false, gen, doc.namespace("java"))
+      gen.renderMustache("struct.mustache", ctrl).trim must include ("tmpFieldMap.put(\"tag1\", \"\\\"value\\\"\")")
+    }
+  }
 }

--- a/scrooge-generator/src/main/resources/apachejavagen/generate_java_enum_value_annotations.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/generate_java_enum_value_annotations.mustache
@@ -10,7 +10,7 @@ static {
     {
       Map<String, String> tmpFieldMap = new HashMap<String, String>();
       {{#value.annotations}}
-      tmpFieldMap.put("{{key}}", "{{value}}");
+      tmpFieldMap.put("{{key}}", "{{{value}}}");
       {{/value.annotations}}
       tmpMap.put({{value.name}}, Collections.unmodifiableMap(tmpFieldMap));
     }

--- a/scrooge-generator/src/main/resources/apachejavagen/generate_java_field_annotations.mustache
+++ b/scrooge-generator/src/main/resources/apachejavagen/generate_java_field_annotations.mustache
@@ -10,7 +10,7 @@ static {
     {
       Map<String, String> tmpFieldMap = new HashMap<String, String>();
       {{#value}}
-      tmpFieldMap.put("{{key}}", "{{value}}");
+      tmpFieldMap.put("{{key}}", "{{{value}}}");
       {{/value}}
       tmpMap.put(_Fields.{{#constant_name}}{{key.originalName}}{{/constant_name}}, Collections.unmodifiableMap(tmpFieldMap));
     }


### PR DESCRIPTION
# Problem

Scrooge generates invalid string escape sequences when the field annotation contains certain characters.

For example:

```thrift
struct Foo {
    1: i32 bar (tag1 = "\"value\"")
}
```

This will be converted to something like:

```java
{
    Map<String, String> tmpFieldMap = new HashMap<String, String>();
    tmpFieldMap.put("tag1", "\&quote;value\&quote;");
    //                       ^------- invalid escape sequences
    tmpMap.put(_Fields.TENANT_ID, Collections.unmodifiableMap(tmpFieldMap));
}
```

# Solution

Mustache will html-escape everything that is wrapped by `{{...}}`. By replacing the `{{value}}` with `{{{value}}}` solves the problem.
