### PR TITLE
avoid deprecated ScalaTest 3.0 APIs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ the maintainers will help out during code review.
 We've standardized on using the [ScalaTest testing framework][scalatest].
 Because ScalaTest has such a big surface area, we use a restricted subset of it
 in our tests to keep them easy to read.  We've chosen the `assert` API, not the
-`Matchers` one, and we use the [`FunSuite` mixin][funsuite], which supports
+`Matchers` one, and we use the [`AnyFunSuite` mixin][funsuite], which supports
 xUnit-like semantics.
 
 Note that while you will see a [Travis CI][travis-ci] status message in your

--- a/demos/scrooge-maven-demo/src/test/scala/com/twitter/example/DemoTest.scala
+++ b/demos/scrooge-maven-demo/src/test/scala/com/twitter/example/DemoTest.scala
@@ -4,9 +4,9 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.mydemo.renamed.User
 import com.twitter.util.{Future, Await}
 import java.net.{InetSocketAddress, SocketAddress}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class DemoTest extends FunSuite {
+class DemoTest extends AnyFunSuite {
   def printUser(user: User): Unit = println("User %s, id %d".format(user.name, user.id))
 
   def await[A](f: Future[A]): A = Await.result(f, 5.seconds)

--- a/scrooge-adaptive/src/test/scala/com/twitter/scrooge/adapt/AdaptiveScroogeTest.scala
+++ b/scrooge-adaptive/src/test/scala/com/twitter/scrooge/adapt/AdaptiveScroogeTest.scala
@@ -16,7 +16,7 @@ import org.apache.thrift.protocol.{TProtocolException, TType}
 import org.junit.runner.RunWith
 import org.scalacheck.Prop.forAll
 import org.scalacheck.{Arbitrary, Prop}
-import org.scalatest.PropSpec
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers
 
@@ -33,7 +33,7 @@ trait Accessor[-T] extends ((T) => Any) {
 }
 
 @RunWith(classOf[JUnitRunner])
-class AdaptiveScroogeTest extends PropSpec with Checkers {
+class AdaptiveScroogeTest extends AnyPropSpec with Checkers {
 
   /**
    * Bytes of thrift struct with no fields set, it's still a valid thrift object.

--- a/scrooge-adaptive/src/test/scala/com/twitter/scrooge/adapt/BinaryThriftFieldRemoverTest.scala
+++ b/scrooge-adaptive/src/test/scala/com/twitter/scrooge/adapt/BinaryThriftFieldRemoverTest.scala
@@ -7,12 +7,12 @@ import org.apache.thrift.protocol.TProtocolException
 import org.junit.runner.RunWith
 import org.scalacheck.Prop
 import org.scalacheck.Prop.forAll
-import org.scalatest.PropSpec
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers
 
 @RunWith(classOf[JUnitRunner])
-class BinaryThriftFieldRemoverTest extends PropSpec with Checkers {
+class BinaryThriftFieldRemoverTest extends AnyPropSpec with Checkers {
   def removeField[T <: ThriftStruct](t: T, codec: ThriftStructCodec[T], fieldId: Short): T = {
     val ser = BinaryThriftStructSerializer(codec)
     val bytes = ser.toBytes(t)

--- a/scrooge-core/src/test/scala/com/twitter/scrooge/ThriftUtilSpec.scala
+++ b/scrooge-core/src/test/scala/com/twitter/scrooge/ThriftUtilSpec.scala
@@ -5,12 +5,12 @@ import org.apache.thrift.transport.TMemoryBuffer
 import org.junit.runner.RunWith
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.scalacheck.Checkers
 
 @RunWith(classOf[JUnitRunner])
-class ThriftUtilSpec extends FunSuite with Checkers {
+class ThriftUtilSpec extends AnyFunSuite with Checkers {
   val recognizedTypeCodes =
     Set(
       TType.VOID,

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/finagle_integration/ScalaIntegrationTest.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/finagle_integration/ScalaIntegrationTest.scala
@@ -9,9 +9,9 @@ import com.twitter.scrooge.finagle_integration.thriftscala.ExtendedBarService.Tr
 import com.twitter.util.{Await, Awaitable, Duration, Future}
 import java.net.{InetAddress, InetSocketAddress}
 import org.apache.thrift.TApplicationException
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ScalaIntegrationTest extends FunSuite {
+class ScalaIntegrationTest extends AnyFunSuite {
 
   def await[T](a: Awaitable[T], d: Duration = 5.seconds): T =
     Await.result(a, d)

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/goldfile/GoldFileTest.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/goldfile/GoldFileTest.scala
@@ -4,7 +4,8 @@ import com.twitter.io.Files
 import com.twitter.scrooge.Main
 import com.twitter.scrooge.testutil.{Utils, TempDirectory}
 import java.io.{ByteArrayInputStream, File, InputStream}
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 import scala.io.Source
 
 /**
@@ -15,7 +16,7 @@ import scala.io.Source
  * intentional due to the corresponding changes in the generator code or
  * templates.
  */
-abstract class GoldFileTest extends FunSuite with BeforeAndAfterAll {
+abstract class GoldFileTest extends AnyFunSuite with BeforeAndAfterAll {
 
   private var tempDir: File = _
   protected var generatedFiles: Seq[File] = _

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/testutil/Spec.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/testutil/Spec.scala
@@ -3,12 +3,13 @@ package com.twitter.scrooge.testutil
 import org.junit.runner.RunWith
 import org.scalatest.fixture.{WordSpec => FixtureWordSpec}
 import org.scalatestplus.junit.JUnitRunner
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.jmock.JMockCycleFixture
 import org.scalatestplus.mockito.MockitoSugar
 
 @RunWith(classOf[JUnitRunner])
-abstract class Spec extends WordSpec with MustMatchers with MockitoSugar
+abstract class Spec extends AnyWordSpec with Matchers with MockitoSugar
 
 @RunWith(classOf[JUnitRunner])
-abstract class JMockSpec extends FixtureWordSpec with MustMatchers with JMockCycleFixture
+abstract class JMockSpec extends FixtureWordSpec with Matchers with JMockCycleFixture

--- a/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/testutil/Utils.scala
+++ b/scrooge-generator-tests/src/test/scala/com/twitter/scrooge/testutil/Utils.scala
@@ -3,9 +3,9 @@ package com.twitter.scrooge.testutil
 import com.google.common.base.Charsets
 import com.google.common.io.CharStreams
 import java.io.{BufferedReader, InputStreamReader}
-import org.scalatest.MustMatchers
+import org.scalatest.matchers.must.Matchers
 
-object Utils extends MustMatchers {
+object Utils extends Matchers {
   def verify(
     actual: String,
     expected: String,

--- a/scrooge-linter/src/test/scala/com/twitter/scrooge/linter/LinterSpec.scala
+++ b/scrooge-linter/src/test/scala/com/twitter/scrooge/linter/LinterSpec.scala
@@ -17,9 +17,10 @@
 package com.twitter.scrooge.linter
 
 import com.twitter.scrooge.ast._
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LinterSpec extends WordSpec with MustMatchers {
+class LinterSpec extends AnyWordSpec with Matchers {
 
   def mustPass(errors: Iterable[LintMessage]) =
     errors.size must equal(0)

--- a/scrooge-serializer/src/test/scala/com/twitter/scrooge/ThriftBadDataTest.scala
+++ b/scrooge-serializer/src/test/scala/com/twitter/scrooge/ThriftBadDataTest.scala
@@ -5,12 +5,12 @@ import com.twitter.scrooge.serializer.thriftscala.SerializerListTest
 import com.twitter.scrooge.serializer.thriftscala.SerializerSetTest
 import com.twitter.scrooge.serializer.thriftscala.SerializerMapTest
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 import org.apache.thrift.TException
 
 @RunWith(classOf[JUnitRunner])
-class ThriftBadDataTest extends FunSuite {
+class ThriftBadDataTest extends AnyFunSuite {
 
   private[this] def encodeI32(buf: Array[Byte], offset: Int, i32: Int): Unit = {
     buf(offset + 0) = (0xff & (i32 >> 24)).toByte

--- a/scrooge-serializer/src/test/scala/com/twitter/scrooge/ThriftStructSerializerTest.scala
+++ b/scrooge-serializer/src/test/scala/com/twitter/scrooge/ThriftStructSerializerTest.scala
@@ -2,11 +2,11 @@ package com.twitter.scrooge
 
 import com.twitter.scrooge.serializer.thriftscala.SerializerTest
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ThriftStructSerializerTest extends FunSuite {
+class ThriftStructSerializerTest extends AnyFunSuite {
 
   test("toBytes and fromBytes round trip") {
     val instance = SerializerTest(5)


### PR DESCRIPTION
Problem                                                                                                                 
                                                                                                                        
The codebase was still using deprecated ScalaTest 3.0 APIs. This was problematic in the Scala 2.13 community build, and it also                                                          
blocks an eventual upgrade to ScalaTest 3.2, where the deprecated APIs are removed.                                                                                                       
                                                                                                                        
Solution                                                                                                                
                                                                                                                        
Use the replacement 3.1/3.2 APIs recommended by the maintainers of ScalaTest.                                                                                                              