### PR TITLE
Using irrefutable extractors for Scala structs

### DIFF
--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/AnotherException.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/AnotherException.scala
@@ -155,7 +155,7 @@ object AnotherException extends ValidatingThriftStructCodec3[AnotherException] w
       errorCode
     )
 
-  def unapply(_item: AnotherException): _root_.scala.Option[Int] = _root_.scala.Some(_item.errorCode)
+  def unapply(_item: AnotherException): _root_.scala.Some[Int] = _root_.scala.Some(_item.errorCode)
 
 
 

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/CollectionId.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/CollectionId.scala
@@ -218,7 +218,7 @@ object CollectionId extends ValidatingThriftStructCodec3[CollectionId] with Stru
       collectionLongId
     )
 
-  def unapply(_item: CollectionId): _root_.scala.Option[Long] = _root_.scala.Some(_item.collectionLongId)
+  def unapply(_item: CollectionId): _root_.scala.Some[Long] = _root_.scala.Some(_item.collectionLongId)
 
 
 

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/GoldService.scala
@@ -420,7 +420,7 @@ object GoldService extends _root_.com.twitter.finagle.thrift.GeneratedThriftServ
           request
         )
     
-      def unapply(_item: Args): _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.Some(_item.request)
+      def unapply(_item: Args): _root_.scala.Some[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.Some(_item.request)
     
     
     
@@ -685,7 +685,7 @@ object GoldService extends _root_.com.twitter.finagle.thrift.GeneratedThriftServ
           ex
         )
     
-      def unapply(_item: Result): _root_.scala.Option[_root_.scala.Tuple2[Option[com.twitter.scrooge.test.gold.thriftscala.Response], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]] = _root_.scala.Some(_item.toTuple)
+      def unapply(_item: Result): _root_.scala.Some[_root_.scala.Tuple2[Option[com.twitter.scrooge.test.gold.thriftscala.Response], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]] = _root_.scala.Some(_item.toTuple)
     
     
     
@@ -966,7 +966,7 @@ object GoldService extends _root_.com.twitter.finagle.thrift.GeneratedThriftServ
           request
         )
     
-      def unapply(_item: Args): _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.Some(_item.request)
+      def unapply(_item: Args): _root_.scala.Some[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.Some(_item.request)
     
     
     
@@ -1193,7 +1193,7 @@ object GoldService extends _root_.com.twitter.finagle.thrift.GeneratedThriftServ
           success
         )
     
-      def unapply(_item: Result): _root_.scala.Option[_root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Response]] = _root_.scala.Some(_item.success)
+      def unapply(_item: Result): _root_.scala.Some[_root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Response]] = _root_.scala.Some(_item.success)
     
     
     

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/OverCapacityException.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/OverCapacityException.scala
@@ -159,7 +159,7 @@ object OverCapacityException extends ValidatingThriftStructCodec3[OverCapacityEx
       chillTimeSeconds
     )
 
-  def unapply(_item: OverCapacityException): _root_.scala.Option[Int] = _root_.scala.Some(_item.chillTimeSeconds)
+  def unapply(_item: OverCapacityException): _root_.scala.Some[Int] = _root_.scala.Some(_item.chillTimeSeconds)
 
 
 

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/PlatinumService.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/PlatinumService.scala
@@ -453,7 +453,7 @@ object PlatinumService extends _root_.com.twitter.finagle.thrift.GeneratedThrift
           request
         )
     
-      def unapply(_item: Args): _root_.scala.Option[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.Some(_item.request)
+      def unapply(_item: Args): _root_.scala.Some[com.twitter.scrooge.test.gold.thriftscala.Request] = _root_.scala.Some(_item.request)
     
     
     
@@ -750,7 +750,7 @@ object PlatinumService extends _root_.com.twitter.finagle.thrift.GeneratedThrift
           oce
         )
     
-      def unapply(_item: Result): _root_.scala.Option[_root_.scala.Tuple3[Option[Int], Option[com.twitter.scrooge.test.gold.thriftscala.AnotherException], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]] = _root_.scala.Some(_item.toTuple)
+      def unapply(_item: Result): _root_.scala.Some[_root_.scala.Tuple3[Option[Int], Option[com.twitter.scrooge.test.gold.thriftscala.AnotherException], Option[com.twitter.scrooge.test.gold.thriftscala.OverCapacityException]]] = _root_.scala.Some(_item.toTuple)
     
     
     

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Recursive.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Recursive.scala
@@ -258,7 +258,7 @@ object Recursive extends ValidatingThriftStructCodec3[Recursive] with StructBuil
       recRequest
     )
 
-  def unapply(_item: Recursive): _root_.scala.Option[_root_.scala.Tuple2[Long, Option[com.twitter.scrooge.test.gold.thriftscala.Request]]] = _root_.scala.Some(_item.toTuple)
+  def unapply(_item: Recursive): _root_.scala.Some[_root_.scala.Tuple2[Long, Option[com.twitter.scrooge.test.gold.thriftscala.Request]]] = _root_.scala.Some(_item.toTuple)
 
 
 

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Request.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Request.scala
@@ -810,7 +810,7 @@ object Request extends ValidatingThriftStructCodec3[Request] with StructBuilderF
       anInt8
     )
 
-  def unapply(_item: Request): _root_.scala.Option[_root_.scala.Tuple15[_root_.scala.collection.Seq[String], _root_.scala.collection.Set[Int], _root_.scala.collection.Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], _root_.scala.collection.Seq[com.twitter.scrooge.test.gold.thriftscala.Request], String, Option[Long], Option[Long], Option[Long], Option[Long], Option[Long], Option[com.twitter.scrooge.test.gold.thriftscala.Recursive], String, Option[Long], Option[Byte]]] = _root_.scala.Some(_item.toTuple)
+  def unapply(_item: Request): _root_.scala.Some[_root_.scala.Tuple15[_root_.scala.collection.Seq[String], _root_.scala.collection.Set[Int], _root_.scala.collection.Map[Long, Long], Option[com.twitter.scrooge.test.gold.thriftscala.Request], _root_.scala.collection.Seq[com.twitter.scrooge.test.gold.thriftscala.Request], String, Option[Long], Option[Long], Option[Long], Option[Long], Option[Long], Option[com.twitter.scrooge.test.gold.thriftscala.Recursive], String, Option[Long], Option[Byte]]] = _root_.scala.Some(_item.toTuple)
 
 
   private[thriftscala] def readAListValue(_iprot: TProtocol): _root_.scala.collection.Seq[String] = {

--- a/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Response.scala
+++ b/scrooge-generator-tests/src/test/resources/gold_file_output_scala/com/twitter/scrooge/test/gold/thriftscala/Response.scala
@@ -258,7 +258,7 @@ object Response extends ValidatingThriftStructCodec3[Response] with StructBuilde
       responseUnion
     )
 
-  def unapply(_item: Response): _root_.scala.Option[_root_.scala.Tuple2[Int, com.twitter.scrooge.test.gold.thriftscala.ResponseUnion]] = _root_.scala.Some(_item.toTuple)
+  def unapply(_item: Response): _root_.scala.Some[_root_.scala.Tuple2[Int, com.twitter.scrooge.test.gold.thriftscala.ResponseUnion]] = _root_.scala.Some(_item.toTuple)
 
 
 

--- a/scrooge-generator/src/main/resources/scalagen/struct.mustache
+++ b/scrooge-generator/src/main/resources/scalagen/struct.mustache
@@ -376,10 +376,10 @@ object {{StructName}} extends ValidatingThriftStructCodec3[{{StructName}}] with 
   def unapply(_item: {{StructName}}): Boolean = true
 {{/arity0}}
 {{#arity1}}
-  def unapply(_item: {{StructName}}): _root_.scala.Option[{{>optionalType}}] = _root_.scala.Some(_item.{{fieldName}})
+  def unapply(_item: {{StructName}}): _root_.scala.Some[{{>optionalType}}] = _root_.scala.Some(_item.{{fieldName}})
 {{/arity1}}
 {{#arityN}}
-  def unapply(_item: {{StructName}}): _root_.scala.Option[{{tuple}}] = _root_.scala.Some(_item.toTuple)
+  def unapply(_item: {{StructName}}): _root_.scala.Some[{{tuple}}] = _root_.scala.Some(_item.toTuple)
 {{/arityN}}
 
 


### PR DESCRIPTION
## Problem

Up until [Scala 2.13.4](https://github.com/scala/scala/pull/9140), having custom extractors in a pattern match disables exhaustivity  checks by the compiler. 
This is true, unless the extractor is "irrefutable", which means that its type-signature contains a `Some` rather than an `Option`.
For more details, see [this](https://nrinaudo.github.io/scala-best-practices/unsafe/custom_extractors.html).

As currently implemented, Thrift structs generate Scala code with "refutable" custom extractors, which can lead to inadvertent and surprising cases where people expect the compiler to do full exhaustivity checking, but that doesn't happen, leading to runtime exceptions.

## Solution

This pull request updates the relevant mustache template to have `Some` in the `unapply` signature, thus turning the extractor into an irrefutable one.

(Note, I'm not quite sure how to go about tests in this project, any pointers would be welcome.)

Thanks
