### PR TITLE
Fix #341 - add setting to configure root dir importer

### DIFF
--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/Compiler.scala
@@ -18,8 +18,9 @@ package com.twitter.scrooge
 
 import com.twitter.scrooge.ast.Document
 import com.twitter.scrooge.backend.{GeneratorFactory, ScalaGenerator}
-import com.twitter.scrooge.frontend.{FileParseException, TypeResolver, ThriftParser, Importer}
+import com.twitter.scrooge.frontend.{FileParseException, Importer, NullImporter, ThriftParser, TypeResolver}
 import com.twitter.scrooge.java_generator.ApacheJavaGenerator
+
 import java.io.{File, FileWriter}
 import scala.collection.concurrent.TrieMap
 
@@ -45,7 +46,7 @@ class Compiler(val config: ScroogeConfig) {
       new FileWriter(file)
     }
 
-    val importer = Importer(new File(".")) +: Importer(config.includePaths.toSeq)
+    val importer = (if(config.addRootDirImporter) Importer(new File(".")) else NullImporter) +: Importer(config.includePaths.toSeq)
 
     val isJava = config.language.equals("java")
     val documentCache = new TrieMap[String, Document]

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/ScroogeOptionParser.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/ScroogeOptionParser.scala
@@ -41,7 +41,9 @@ case class ScroogeConfig(
   language: String = CompilerDefaults.language,
   defaultNamespace: String = CompilerDefaults.defaultNamespace,
   scalaWarnOnJavaNSFallback: Boolean = false,
-  javaSerEnumType: Boolean = false)
+  javaSerEnumType: Boolean = false,
+  addRootDirImporter: Boolean = true
+)
 
 object ScroogeOptionParser {
 


### PR DESCRIPTION
## Problem

As described in #341 a lot of warnings are generated when using scrooge in projects with sbt sub modules as a root dir importer is always added.

## Solution

Add a new setting `scroogeThriftIncludeRoot` that makes this behaviour configurable.
The default behaviour is as it is now.

## Result

Users won't see a ton of warnings.
