### PR TITLE
Portable shebang

### DIFF
--- a/pushsite.bash
+++ b/pushsite.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/sbt
+++ b/sbt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/scrooge-generator-tests/src/test/resources/gen_gold_files.sh
+++ b/scrooge-generator-tests/src/test/resources/gen_gold_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/scrooge-linter/src/scripts/linter-test
+++ b/scrooge-linter/src/scripts/linter-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run from source root
 # e.g. ./pants bundle scrooge/scrooge-linter:app \


### PR DESCRIPTION
Problem

- /bin/bash is not available on non-FHS distros, such as NixOS

Solution

- replace `/bin/bash` with `/usr/bin/env bash` 	

Result


See also


https://github.com/twitter/dodo/pull/15
https://github.com/twitter/finagle/pull/959
https://github.com/twitter/finatra/pull/589
https://github.com/twitter/util/pull/314
https://github.com/twitter/twitter-server/pull/77